### PR TITLE
Improve PackageBuilding

### DIFF
--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -42,6 +42,10 @@ From within the package repository:
       lxc exec builder -- tar cf - --exclude=package -C /root/build . | tar xf - -C .. &&
     $ lxc delete -f builder
 
+Even though the recommended way to build a source package is to use a pristine environment inside an LXD container, you can also use `dpkg-buildpackage`'s `--no-check-builddeps` option and build the source package locally:
+
+    $ dpkg-buildpackage -S -d
+
 
 ### Signing the Changes File
 

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -68,6 +68,16 @@ From within the package repository:
 
 Other flags are similar to `git ubuntu build --source`.
 
+### Using sbuild
+
+Assuming you have configured `sbuild` properly, you can use it to build the binary package:
+
+    $ sbuild
+
+Because of https://bugs.launchpad.net/launchpad/+bug/1699763, it is a good idea to disable the inclusion of `.buildinfo` files in the `*_source.changes` file:
+
+    $ sbuild --debbuildopts='--buildinfo-option=-O'
+
 
 ### As a PPA in Launchpad
 

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -4,6 +4,15 @@ Package Building
 There are multiple ways to build a package, each with advantages and disadvantages. Which one you choose will depend on your circumstances.
 
 
+Downloading the orig tarball (optional)
+---------------------------------------
+
+If you intend to use more manual methods like `sbuild` or `dpkg-buildpackage` directly, you will probably have to download the orig tarball first.  You can do so by using:
+
+    $ git ubuntu export-orig
+
+It will try to use the `pristine-tar` branch to generate the tarball (and will likely fail), and then it will fallback to downloading the tarball directly from Launchpad.  When it finishes, you should be able to see a link to the orig tarball at `../`.
+
 
 Building Source Packages
 ------------------------

--- a/Setup.md
+++ b/Setup.md
@@ -83,8 +83,13 @@ Your user should be a member of the following groups:
 
 Your `.profile` should include entries for `DEBFULLNAME` and `DEBEMAIL`:
 
-    $ export DEBFULLNAME="Your Full Name"
-    $ export DEBEMAIL=your@email.com
+    export DEBFULLNAME="Your Full Name"
+    export DEBEMAIL=your@email.com
+
+You can also set the `DEBSIGN` variables:
+
+    export DEBSIGN_PROGRAM="/usr/bin/gpg2"
+    export DEBSIGN_KEYID="0xMYKEYHASH"
 
 A fix for "clear-sign failed: Inappropriate ioctl for device":
 


### PR DESCRIPTION
This series of commits aim at improving the current PackageBuilding page.  These are the additions I've made:
  * New section **Downloading the orig tarball (optional)**
  * Improve on section **Building Source Packages** (by mentioning that it's possible to invoke `dpkg-buildpackage` locally as well).
  * New section **Using sbuild**, which also mentions how to workaround a Launchpad PPA bug.

Finally, I also mention the possibility of setting the `DEBSIGN_*` variables on `.profile`.