### PR TITLE
Packageset membership

### DIFF
--- a/Concepts.md
+++ b/Concepts.md
@@ -140,16 +140,26 @@ Apt uses `sources.list` and `sources.list.d` to tell it which suites to use.
 
 Example /etc/apt/sources.list:
 
-    deb http://de.archive.ubuntu.com/ubuntu/ bionic main restricted universe
-    deb-src http://de.archive.ubuntu.com/ubuntu/ bionic main restricted universe
+    deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe
+    deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe
 
     ## Major bug fix updates produced after the final release of the distribution.
-    deb http://de.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe
-    # deb-src http://de.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe
+    deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe
+    # deb-src http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe
+
+    ## Important security fixes.
+    deb http://security.ubuntu.com/ubuntu/ focal-security main restricted universe
+    # deb-src http://security.ubuntu.com/ubuntu/ focal-security main restricted universe
 
 When apt encounters multiple versions of a package, it uses an internal scoring system to decide which version should be installed.
 
 Notice that some lines start with 'deb', while others 'deb-src'.  The 'deb' lines provide binary packages, while the 'deb-src' provide source packages.  You'll usually notice the 'deb-src' lines are commented out with '#' to disable them; this makes updates run a bit faster for the vast majority of people who don't need access to the sources.  You're one of the select few who do need access, so uncomment the 'deb-src' lines appropriate you what you'll be working on.
+
+Depending on your geographical area, you may find it beneficial to pull from one of Canonical's mirrors.  To do this, replace the hostname portion of each line above with the corresponding mirror hostname.  For example, in Germany you might use:
+
+    deb http://de.archive.ubuntu.com/ubuntu/ focal main restricted universe
+    deb-src http://de.archive.ubuntu.com/ubuntu/ focal main restricted universe
+    # etc.
 
 
 ### Partial Suites

--- a/MembershipInPackageSet.md
+++ b/MembershipInPackageSet.md
@@ -1,0 +1,81 @@
+Membership in Package Set
+-------------------------
+
+Upload rights can be given for certain package-sets, such as 'server' or 'desktop'.  Its original design intent was for individuals who will only be working on a very small set of packages.
+
+For this reason, some people skip this level and head straight for MOTU or core-dev instead; if you already have strong packaging experience via another distro you certainly can consider doing similarly.
+
+That said, even if you intend to eventually apply for core-dev, gaining package-set first can be an effective way to build towards those roles, allowing you to upload your own work (within limits) and participate in reviews and sponsorship of co-workers.
+
+
+Application Process
+-------------------
+
+0.  *Important*  [Check the DMB agenda](https://wiki.ubuntu.com/DeveloperMembershipBoard/Agenda) to see when the DMB next meeting is, and to check the queue of applications.  Only 2 applications are considered each meeting so if there's a queue, make sure to reserve a spot for when you think you'll be ready for consideration.
+
+1.  Create a short wiki page for yourself, at https://wiki.ubuntu.com/FirstnameLastname/, that introduces yourself and your past Ubuntu-related work, and includes a Contact Information section with at least your IRC nick and Launchpad ID.  You can look at other people's pages for other ideas of things to include.  You'll be reusing this text in your membership applications later.
+
+2.  Training and Preparation, as needed.  See the following section for details.
+
+3.  Prepare your Application Form.  Load https://wiki.ubuntu.com/FirstnameLastname/PackagesetDeveloperApplication, replacing FirstnameLastname with what you used in step 0.  Select "UbuntuDevelopment/DeveloperApplicationTemplate" from the list of templates, and follow its directions on how to fill it out; you can look at [past applications](https://wiki.ubuntu.com/Home?action=fullsearch&context=180&value=DeveloperApplication&titlesearch=Titles) such as [Paride's](https://wiki.ubuntu.com/ParideLegovini/UbuntuServerDeveloperApplication) as examples.  Specify at the top that you're "applying for upload rights to the Ubuntu Server package set", replacing "Ubuntu Server" as appropriate, or listing out the exact, specific packages.
+
+4.  Collect Endorsements from people who have sponsored your packages.  Ask on your team's regular discussion channels, and individually contact each of your sponsors not in your team.  It's good form to only ask people who have sponsored multiple packages for you, or that have worked with you on particularly tricky packaging efforts.  You want to strike a good balance between quality and quantity here.
+
+5.  [Apply for team membership](https://wiki.ubuntu.com/DeveloperMembershipBoard/ApplicationProcess) by announcing on the devel-permissions@ mailing list and adding your name to the DMB agenda (if you haven't already).
+
+6.  Review past meeting logs to get a sense for what to expect.
+
+7.  Attend meeting, answer questions, and receive your votes.
+
+
+Training and Preparation
+------------------------
+
+We're going to describe an idealized training program here, however no application is exactly the same, and as such there is a lot of flexibility in expectations.  This is particularly true for packageset given that it is by definition of limited scope - just be prepared to give extra justification if you diverge substantially.
+
+Ideally, you should have a solid mastery of the [basic packaging skills](https://packaging.ubuntu.com/html/) for Debian/Ubuntu distributions, including the following:
+
+  * [Fixing bugs in packages](PackageFixing)
+  * Building binary packages from source using sbuild or debuild in a chroot or lxc environment
+  * Creating the initial packaging for new software
+  * Merging updates from Debian
+  * Backporting patches
+  * Forwarding bugs and patches to Debian and to upstream maintainers
+  * Stable Release Update process
+
+Make sure you've done each of the above items at least a couple of times.  If you're not comfortable with any of these, plan on doing some additional practice with them.
+
+You should also work towards understanding some more advanced packaging topics:
+
+  * Purpose of the [different files in debian/](https://packaging.ubuntu.com/html/debian-dir-overview.html)
+  * [Debian policy](http://www.debian.org/doc/debian-policy/)
+  * [Ubuntu's release process](https://wiki.ubuntu.com/UbuntuDevelopment/ReleaseProcess), including the
+    [freeze exception process](https://wiki.ubuntu.com/FreezeExceptionProcess)
+  * Running [Autopkgtest](PackageTests)
+  * Troubleshooting [https://wiki.ubuntu.com/ProposedMigration](migration of packages) from -proposed
+
+While you may not have direct experience with some or most of these topics, you should at least be conversant in all of them conceptually.
+
+In addition to Ubuntu packaging, you will need to have some technical expertise with the subset of software you'll be working on, and the processes and procedures standardized for them.  For example, for the Ubuntu server team you would need to have experience with technologies such as systemd and networking, and processes such as using git-ubuntu for package maintenance.
+
+Keep in mind the DMB's perspective will follow the "Need to unblock" principle:  They want to approve applications that will help either reduce contributor friction or to save work of sponsors.  Establishing yourself as an area expert that is a resource for contributors helps prove the former, and your volume and frequency of uploads justifies the latter.
+
+Collaboration with the upstream(s) related to the software within your packageset is important as well.  Gain experience with your upstreams' bug reporting processes, patch review processes, and testing/CI systems if you haven't so far.  In general, the narrower the number of packages you plan to focus on, the stronger your collaboration with upstream you should be able to show.
+
+And on the flip side, if you are a Canonical employee you will need to be able to negotiate the distinction between Ubuntu governance and Canonical priorities, within your area of focus.  Sometimes these can appear to collide and require a certain level of diplomacy to find solutions that work well for both sides.  The less experience you have in Debian or other open source communities, the more thought you'll want to put into this.
+
+Finally, you'll know you're past ready for applying if anyone ever asks, "How do you not already have upload rights??"
+
+
+Further Information
+-------------------
+
+  * https://wiki.ubuntu.com/RobieBasak/DMB/CoreDev
+  * https://wiki.ubuntu.com/UbuntuDevelopers
+
+Once you've been granted packageset upload permissions, there are at least three distinct directions you could embark on, depending on your goals:
+
+  * MOTU, if you want to get depth into the Ubuntu packaging world.
+  * Membership in packaging teams at other distributions, if you want to broaden the reach of your software.
+  * Upstream maintainership in your project(s) of interest, if you want to pursue more focus in the development of the software itself.
+

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -20,11 +20,11 @@ Building Source Packages
 
 ### Using dpkg-buildpackage
 
-This method will directly install any dependencies it needs to build, so it's recommended to create an LXD container to do the build. Replace `bionic` with the container image you wish to use.
+This method will directly install any dependencies it needs to build, so it's recommended to create an LXD container to do the build. Replace `focal` with the container image you wish to use.
 
 From within the package repository:
 
-    $ lxc launch ubuntu-daily:bionic builder &&
+    $ lxc launch ubuntu-daily:focal builder &&
       sleep 5 &&
       lxc exec builder -- mkdir -p /root/build/package &&
       tar cf - . | lxc exec builder -- tar xf - -C /root/build/package &&

--- a/PackageTests.md
+++ b/PackageTests.md
@@ -23,18 +23,18 @@ Important restrictions:
 
 #### Building a VM Image
 
-Create an image like this (replacing bionic with your release of choice):
+Create an image like this (replacing focal with your release of choice):
 
-    $ autopkgtest-buildvm-ubuntu-cloud -r bionic -v --cloud-image-url http://cloud-images.ubuntu.com/daily/server
+    $ autopkgtest-buildvm-ubuntu-cloud -r focal -v --cloud-image-url http://cloud-images.ubuntu.com/daily/server
 
 Note: Use `-m` to specify a closer mirror or `-p` to use a local proxy if it's slow.
 
-Copy the resulting image (autopkgtest-bionic-amd64.img) to a common directory like `/var/lib/adt-images`
+Copy the resulting image (autopkgtest-focal-amd64.img) to a common directory like `/var/lib/adt-images`
 
 
 #### Building a Container Image
 
-    $ autopkgtest-build-lxd ubuntu-daily:bionic/amd64
+    $ autopkgtest-build-lxd ubuntu-daily:focal/amd64
 
 You should see an autopkgtest image now when you run `lxc image list`.
 
@@ -46,7 +46,7 @@ You should see an autopkgtest image now when you run `lxc image list`.
 
 Make sure you're one directory up from your package directory and run:
 
-    $ autopkgtest -U -s -o dep8-mypackage mypackage/ -- qemu /var/lib/adt-images/autopkgtest-bionic-amd64.img
+    $ autopkgtest -U -s -o dep8-mypackage mypackage/ -- qemu /var/lib/adt-images/autopkgtest-focal-amd64.img
 
 Where:
 
@@ -60,7 +60,7 @@ Everything after the `--` tells it how to run the tests. `qemu` is shorthand for
 
 #### In a VM, Using the PPA
 
-    $ autopkgtest -U -s -o dep8-mypackage-ppa --setup-commands="sudo add-apt-repository -y -u -s ppa:mylaunchpaduser/bionic-mypackage-fixed-something-1234567" -B mypackage -- qemu /var/lib/adt-images/autopkgtest-bionic-amd64.img
+    $ autopkgtest -U -s -o dep8-mypackage-ppa --setup-commands="sudo add-apt-repository -y -u -s ppa:mylaunchpaduser/focal-mypackage-fixed-something-1234567" -B mypackage -- qemu /var/lib/adt-images/autopkgtest-focal-amd64.img
 
 Where (in setup-commands):
 
@@ -76,7 +76,7 @@ Note: In this case, the package name **doesn't** have a trailing slash because w
 
 The command only differs after the `--` part. For example:
 
-    $ autopkgtest -U -s -o dep8-mypackage-ppa --setup-commands="sudo add-apt-repository -y -u -s ppa:mylaunchpaduser/bionic-mypackage-fixed-something-1234567" -B mypackage -- lxd autopkgtest/ubuntu/bionic/amd64
+    $ autopkgtest -U -s -o dep8-mypackage-ppa --setup-commands="sudo add-apt-repository -y -u -s ppa:mylaunchpaduser/focal-mypackage-fixed-something-1234567" -B mypackage -- lxd autopkgtest/ubuntu/focal/amd64
 
 
 ### Save the Results
@@ -84,7 +84,7 @@ The command only differs after the `--` part. For example:
 You'll see the tests run:
 
     autopkgtest [11:47:12]: version 5.3.1
-    autopkgtest [11:47:12]: host karl-tp; command line: /usr/bin/autopkgtest -U -s -o dep8-postfix-ppa '--setup-commands=sudo add-apt-repository -y -u -s ppa:kstenerud/postfix-postconf-segfault-1753470' -B postfix -- lxd autopkgtest/ubuntu/bionic/amd64
+    autopkgtest [11:47:12]: host karl-tp; command line: /usr/bin/autopkgtest -U -s -o dep8-postfix-ppa '--setup-commands=sudo add-apt-repository -y -u -s ppa:kstenerud/postfix-postconf-segfault-1753470' -B postfix -- lxd autopkgtest/ubuntu/focal/amd64
     autopkgtest [11:47:31]: @@@@@@@@@@@@@@@@@@@@ test bed setup
 
     ...

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ Sections
  * Reviewing
    - [Reviewing Merge Proposals](MergeProposalReview.md)
    - [Bug Triage](BugTriage.md)
+ * Requesting Upload Rights
+   - [PackageSet](MembershipInPackageSet.md)

--- a/Setup.md
+++ b/Setup.md
@@ -245,7 +245,7 @@ Template:
     $maintainer_name='Your Full Name <your@email.com>';
 
     # Default distribution to build.
-    $distribution = "bionic";
+    $distribution = "focal";
     # Build arch-all by default.
     $build_arch_all = 1;
 


### PR DESCRIPTION
First cut at a page explaining packageset membership.

Yes, there is already official documentation in the main wiki but this combines that with advice from https://wiki.ubuntu.com/RobieBasak/DMB/CoreDev and presents the information in more of a concise worksheet geared to server team members.

The other commit updates some of the examples from bionic to focal, where it could be done with no impact to the example (i.e. by making version numbers inaccurate).