### PR TITLE
Docker is a container runtime, not Dropbox

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -293,7 +293,7 @@ More Info: https://wiki.ubuntu.com/SimpleSbuild
 
 ### Software: LXD
 
-LXD is a powerful container system similar in concept to Dropbox and other container software.
+LXD is a powerful container system similar in concept to Docker and other container software.
 
 Install and setup LXD using the standard installation directions.
 


### PR DESCRIPTION
I'm guessing this is a typo, as a cursory search didn't turn up any "Dropbox" container runtime.