### PR TITLE
Switch image from ubuntu-daily:$release to images:ubuntu/$release

### DIFF
--- a/PackageTests.md
+++ b/PackageTests.md
@@ -34,7 +34,7 @@ Copy the resulting image (autopkgtest-focal-amd64.img) to a common directory lik
 
 #### Building a Container Image
 
-    $ autopkgtest-build-lxd ubuntu-daily:focal/amd64
+    $ autopkgtest-build-lxd images:ubuntu/impish/amd64
 
 You should see an autopkgtest image now when you run `lxc image list`.
 


### PR DESCRIPTION
In the past, I've used ubuntu-daily:focal but I've been hitting
lots of weird issues. The squad then suggested using images:ubuntu/focal
instead and those images have been working flawlessly.

Very recently, our new starter, Miriam, hit the same issue where
the former image didn't really work and the latter did. There
are more issues with the former one so suggesting the latter one FTW.

And whilst at it, also switch to devel release, that is, from Focal
to Impish.