### PR TITLE
Drop ubuntu-daily:$release in favor of images:ubuntu/$release

### DIFF
--- a/MergeProposal.md
+++ b/MergeProposal.md
@@ -24,7 +24,7 @@ Example SRU merge proposal:
 
     Steps to test:
 
-    # lxc launch ubuntu-daily:bionic builder
+    # lxc launch images:ubuntu/bionic builder
     # lxc exec builder bash
 
     # apt dist-upgrade

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -24,7 +24,7 @@ This method will directly install any dependencies it needs to build, so it's re
 
 From within the package repository:
 
-    $ lxc launch ubuntu-daily:focal builder &&
+    $ lxc launch images:ubuntu/focal builder &&
       sleep 5 &&
       lxc exec builder -- mkdir -p /root/build/package &&
       tar cf - . | lxc exec builder -- tar xf - -C /root/build/package &&

--- a/PackageFixing.md
+++ b/PackageFixing.md
@@ -67,7 +67,7 @@ Before that, we need to set up an environment for doing the testing.  There's ma
 
 #### Make a container for testing:
 
-    $ lxc launch ubuntu-daily:bionic tester
+    $ lxc launch images:ubuntu/bionic tester
     $ lxc exec tester -- bash
 
 #### Alternatively: Make a VM for testing:

--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -573,7 +573,7 @@ Example:
 
 Note: Disco is not yet available at the time of writing, so we use cosmic.
 
-    $ lxc launch ubuntu-daily:cosmic tester && lxc exec tester bash
+    $ lxc launch images:ubuntu/cosmic tester && lxc exec tester bash
     $ apt update && apt dist-upgrade -y && apt install -y at
 
 The test:
@@ -598,7 +598,7 @@ Test the upgraded version:
 
 ### Test installing the latest from scratch
 
-    $ lxc launch ubuntu-daily:cosmic tester && lxc exec tester bash
+    $ lxc launch images:ubuntu/cosmic tester && lxc exec tester bash
     $ add-apt-repository -y ppa:kstenerud/at-merge-lp1802914
     $ apt update && apt dist-upgrade -y && apt install at
     $ echo "echo abc >test.txt" | at now + 1 minute && sleep 1m && cat test.txt && rm test.txt


### PR DESCRIPTION
With #20 being merged in, this does the follow-up fixes of
more mentions of the ubuntu-daily images.

I've intentionally let "cosmic" and "bionic" remain there
and did not convert them to more recent releases because
I believe that'd be a separate thing from this.

I'll do the switch from mentions of older releases to the newer
ones soon, too. But it isn't a blocker, really.