### PR TITLE
PackageBuilding.md: Removing reference to git ubuntu --sign

### DIFF
--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -46,9 +46,9 @@ Even though the recommended way to build a source package is to use a pristine e
 
 ### Signing the Changes File
 
-In order for a source package to be accepted by Launchpad, it must be signed. You can build the sources using `git-ubuntu` with the `--sign` flag, or you can sign it manually with `debsign`:
+In order for a source package to be accepted by Launchpad, it must be signed. You can sign it manually with `debsign` (within the package folder):
 
-    debsign $(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
+    debsign ../$(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
 
 
 


### PR DESCRIPTION
Hi team,

I found a reference to the former option --sign of git-ubuntu (I suppose is from git ubuntu build-source that is no longer available).
I made a few changes that reflect that and also a fix for using the command as copy-paste directly.

Thanks!