### PR TITLE
Document fetching detached gpg signature file

### DIFF
--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -795,7 +795,7 @@ Next step: [Fix the Changelog](#fix-the-changelog)
     $ git checkout merge-lp1802914-disco
     $ cd /tmp
     $ pull-debian-source at
-    $ mv at_3.1.23.orig.tar.gz ~/work/packages/ubuntu/
+    $ mv at_3.1.23.orig.tar.gz{,.asc} ~/work/packages/ubuntu/
     $ cd -
 
 Next step: [Check the source for errors](#check-the-source-for-errors)


### PR DESCRIPTION
When manually pulling the sources for a new merge, one should also get
the gpg signature file, if available. This patch changes the line
suggesting the mv command after the Debian sources are fetched to
suggest that such file should also be moved over.

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>