### PR TITLE
Generate html and pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+html
+Command not found

--- a/generate-html
+++ b/generate-html
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# -*- coding: utf-8; mode: sh -*
+
+(which pandoc >/dev/null) || {
+    echo "Please install pandoc to use this script:"
+    echo "  $ sudo apt-get install pandoc"
+    exit 1
+}
+
+mkdir -p html
+
+tmp_filter=$(mktemp links-to-html-XXXX.lua)
+trap "rm -f '${tmp_filter}'" EXIT
+cat <<EOF > ${tmp_filter}
+function Link(el)
+  el.target = string.gsub(el.target, "%.md", ".html")
+  return el
+end
+EOF
+
+src=$(grep \.md README.md | cut -d\( -f2 | cut -d\) -f1)
+
+for file in README.md ${src}; do
+    pandoc -f gfm \
+           -t html5 "${file}" \
+           --lua-filter="${tmp_filter}" \
+           -o "html/${file%%.md}.html"
+done
+
+echo
+echo "HTML generated:"
+ls -l  html/

--- a/generate-pdf
+++ b/generate-pdf
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# -*- coding: utf-8; mode: sh -*
+
+(which pandoc >/dev/null && which xelatex >/dev/null) || {
+    echo "Please install pandoc and xelatex to use this script:"
+    echo "  $ sudo apt-get install pandoc texlive-latex-extra texlive-xetex"
+    exit 1
+}
+
+src=$(grep \.md README.md | cut -d\( -f2 | cut -d\) -f1)
+
+# FIXME: UTF-8 characters don't work with the default font
+pandoc --pdf-engine=xelatex README.md ${src} -o ubuntu-maintainers-handbook.pdf || {
+    echo "Failed to generate PDF"
+    exit 1
+}
+
+echo
+echo "PDF generated:"
+ls -l  ubuntu-maintainers-handbook.pdf


### PR DESCRIPTION
Adds a couple pandoc scripts to generate HTML and PDF output.

The HTML uses GitHub-Formatted Markdown (gfm) style, which seems to reasonably match the generated output we have on github.

The PDF output doesn't preserve UTF-8 symbols, and doesn't linkify URLs, but is probably good enough if people want to print out the doc or whatnot.

Both these could probably be done better with a Makefile, but will leave that to future work for someone that'd prefer it.  :-)