### PR TITLE
Setup: replace no more available qemu-kvm

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -35,8 +35,7 @@ Software
         pastebinit \
         piuparts \
         pkg-config \
-        qemu \
-        qemu-kvm \
+        qemu-system \
         quilt \
         sbuild \
         snapcraft \


### PR DESCRIPTION
This is an old reference that shall no more be used.
It also causes conflicts on some installations.