### PR TITLE
Explain how to run autopkgtests on a PPA using tooling

### DIFF
--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -50,7 +50,7 @@ In order for a source package to be accepted by Launchpad, it must be signed. De
 
     $ debsign ../<filename>_source.changes
 
-#### Protip
+#### Tip
 
 To save the chore of determining the changes file, you could create a script that extracts the info from the debian/changelog:
 
@@ -83,7 +83,7 @@ For the text, you can use any string as desired; often people use their username
 As an aside, you'll sometimes run across the suffix style "~18.04.1" which is adopted for reasons similar to the codename, and tends to be a preferred choice in semi-official PPAs such as ones used for official customer deliveries or formally maintained backports to the wider userbase.  To avoid confusion, the '~<codename>N' style may be better for the one-off testing-oriented PPAs being discussed here.
 
 
-#### Protip
+#### Tip
 
 Note, the command below can be used to modify the version for PPA usage:
 
@@ -144,7 +144,7 @@ When it finishes, you should be able to see it e.g. https://launchpad.net/~ksten
 
 Note: You must wait for the package to build server-side before you can use the PPA to install packages. This might take anywhere from a few minutes to a few hours depending on how busy things are!  It'll first build the binaries for each architecture, then publish the source and binary packages to be publically downloadable.
 
-#### Protip
+#### Tip
 
 You can use the `ppa` tool to poll launchpad for progress status:
 

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -41,49 +41,87 @@ From within the package repository:
 
 Even though the recommended way to build a source package is to use a pristine environment inside an LXD container, you can also use `dpkg-buildpackage`'s `--no-check-builddeps` option and build the source package locally:
 
-    $ dpkg-buildpackage -S -d
+    $ dpkg-buildpackage -S -I -i -nc --no-check-builddeps
 
 
 ### Signing the Changes File
 
-In order for a source package to be accepted by Launchpad, it must be signed. You can sign it manually with `debsign` (within the package folder):
+In order for a source package to be accepted by Launchpad, it must be signed. Depending on if your GPG keys are properly installed, `dpkg-buildpackage` may automatically sign for you.  Or you can sign it manually with `debsign` on the changes file:
 
-    debsign ../$(grep "Source: " debian/control | sed "s/Source: \(.*\)/\1/g")_$(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")_source.changes
+    $ debsign ../<filename>_source.changes
 
+#### Protip
 
+To save the chore of determining the changes file, you could create a script that extracts the info from the debian/changelog:
 
-Building Binary Packages
-------------------------
-
-### Using sbuild
-
-Assuming you have configured `sbuild` properly, you can use it to build the binary package:
-
-    $ sbuild
-
-Because of https://bugs.launchpad.net/launchpad/+bug/1699763, it is a good idea to disable the inclusion of `.buildinfo` files in the `*_source.changes` file:
-
-    $ sbuild --debbuildopts='--buildinfo-option=-O'
+    $ source_package=$(dpkg-parsechangelog -n1 --show-field Source)
+    $ version=$(dpkg-parsechangelog -n1 --show-field Version)
+    $ debsign "../${source_package}_${version}_source.changes
 
 
-### As a PPA in Launchpad
+Building Binary Packages via PPA
+--------------------------------
 
-Launchpad can build binary packages from your signed source packages and store them in PPA archives. This is especially useful because reviewers of your merge proposal will have a ready binary to test from. The disadvantage is that during busy times, it can take awhile for your package to come up in the build queue.
+Arguably the easiest way to build your package is to let Launchpad do it for you.  "Personal Package Archives", or "PPAs" are encapsulated build spaces in Launchpad but owned and controlled by you.  Packages you sign and upload to a PPA will be built with the same machinery as the official Ubuntu packages, so they're also a great way to verify your work before formally submitting it to Ubuntu.
+
+Once built, the packages in the PPA are publically available, allowing you to share them with bug reporters for testing fixes, and to reviewers of your merge proposals who can readily use them for testing.
+
+The downsides to PPAs are first, they share resources with other Launchpad build processes so during busy times it can take a while to come up in the build queue; second, it's less hands-on than a local build so can be hard to use for highly iterative workflows like sorting out dependency issues or git-bisecting build failures (if you expect that you'll need to debug the build, like going into the environment to modify and retry, a local build is recommended - see below); and third, the PPAs are picky about version strings.
 
 
 #### Set the Version String
 
-For the PPA, we need to change the version in the changelog that's lower than the version we plan to release. Since the tilde `~` character sorts lower than everything else in launchpad, we can simply append `~ppa1` to the version string in `debian/changelog`. For example:
+For the PPA, we need to change the version in the changelog that's lower than the official version we plan to release. Since the tilde `~` character sorts lower than everything else in launchpad, we can simply append `~<string>1` to the version string in `debian/changelog`. For example:
 
     -postfix (3.3.0-1ubuntu0.1) bionic; urgency=medium
-    +postfix (3.3.0-1ubuntu0.1~ppa1) bionic; urgency=medium
+    +postfix (3.3.0-1ubuntu0.1~bionic1) bionic; urgency=medium
 
-Note: The command below can be used to modify the version for PPA usage:
-sed -i "s/\($(grep "urgency=" debian/changelog|head -1|sed "s/.*(\(.*\)).*/\1/g")\)/\1~ppa1/g" debian/changelog 
+Having a numeric digit in this suffix is important because once Launchpad has accepted your upload, it won't accept another one with that same version number (nor any earlier version number).  So if you need to fix something in your upload, even just copyediting your changelog entry, you need an incrementally higher version number.  Incrementing the suffix allows you to do this without needing to modify the official version number.
 
-Note: If a PPA is used to build the package and the version string was changed like above, once needs to rerun dpkg-buildpackage -S -d.
+For the text, you can use any string as desired; often people use their username, or just 'ppa'.  An advantage of using the release codename, however, is if you later intend to port the same package to multiple releases (e.g. you're doing an MRE, or an SRU that has the same official version in multiple Ubuntu releases), using the codename ensures each has a unique version (for Launchpad) while helping indicate which package to use for which Ubuntu release (for users).
+
+As an aside, you'll sometimes run across the suffix style "~18.04.1" which is adopted for reasons similar to the codename, and tends to be a preferred choice in semi-official PPAs such as ones used for official customer deliveries or formally maintained backports to the wider userbase.  To avoid confusion, the '~<codename>N' style may be better for the one-off testing-oriented PPAs being discussed here.
+
+
+#### Protip
+
+Note, the command below can be used to modify the version for PPA usage:
+
+    $ codename="bionic"
+    $ dch -l "~${codename}1" --distribution "${codename}" "Build for PPA"
+
+If a PPA is used to build the package and the version string was changed as described above, make sure to rebuild and resign the source package:
+
+    $ dpkg-buildpackage -S -I -i -nc -d
+
 
 #### Create the PPA archive
+
+First, install 'ppa-dev-tools' from its git repository:
+
+    $ git clone git://git.launchpad.net/ppa-dev-tools
+    $ cd ppa-dev-tools
+
+Next, follow the directions in INSTALL.md to install prereqs and install the tool.
+
+Then to use it:
+
+    $ ppa create <ppa-name>
+
+(The first time you run this it'll ask for authentication via the web.)
+
+This creates the PPA for you, and enables all available build architectures.
+
+You can use whatever you want for your `ppa-name`, so long as its unique in your own namespace.  For consistency, you may want to use a standard naming style, such as:
+
+    $ ppa_name="<package>-<type>-<lpbug>-<desc>"
+
+So for example, you might have PPAs named `apache2-sru-lp12345678`, `clamav-fix-lp1920217`, `clamav-fix-lp1920217-alternative`.
+
+
+#### (Optional) Create the PPA archive (via web)
+
+Alternatively, you can create PPAs directly via Launchpad's web interface.
 
 Go to your launchpad page (https://launchpad.net/~your-username) and click "Create a new PPA". Give it a name such that you'll remember what it's about in a few months. A useful form is `package-type-lpbug-description`:
 
@@ -97,11 +135,40 @@ Now click "Activate".
 
 It is also helpful to enable all architectures to ensure no build regressions were introduced. Do so by clicking on `Change Details` in the newly created PPA page, and then selecting the other architectures.
 
+
 #### Upload the source package
 
-    $ dput ppa:kstenerud/postfix-sru-lp1753470-segfault ../bionic-postfix_3.3.0-1ubuntu0.1~ppa1_source.changes
+    $ dput ppa:kstenerud/postfix-sru-lp1753470-segfault ../postfix_3.3.0-1ubuntu0.1~bionic1_source.changes
 
 When it finishes, you should be able to see it e.g. https://launchpad.net/~kstenerud/+archive/ubuntu/postfix-postconf-segfault-1753470/+packages
 
-Note: You must wait for the package to build server-side before you can use the PPA to install packages. This might take time depending on how busy things are!
+Note: You must wait for the package to build server-side before you can use the PPA to install packages. This might take anywhere from a few minutes to a few hours depending on how busy things are!  It'll first build the binaries for each architecture, then publish the source and binary packages to be publically downloadable.
+
+#### Protip
+
+You can use the `ppa` tool to poll launchpad for progress status:
+
+    $ ppa wait ppa:kstenerud/postfix-sru-lp1753470-segfault
+
+It will exit with 0 once the PPA packages have fully built.
+
 Launchpad also sends status updates notification mails, so monitor your inbox.
+
+
+Building Binary Packages Locally
+--------------------------------
+
+### Using sbuild
+
+Assuming you have configured `sbuild` properly, you can use it to build the binary package:
+
+    $ sbuild
+
+Because of https://bugs.launchpad.net/launchpad/+bug/1699763, it is a good idea to disable the inclusion of `.buildinfo` files in the `*_source.changes` file:
+
+    $ sbuild --debbuildopts='--buildinfo-option=-O'
+
+For more information see:
+
+  * https://packaging.ubuntu.com/html/setting-up-sbuild.html
+  * https://wiki.debian.org/sbuild

--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -537,7 +537,7 @@ Notice above that you must also change the `changelog` rebase command to `fixup`
 The range old/ubuntu..logical/<version> should contain no changes to debian/changelog at all. 
 We do not consider this part of the logical delta. So any commits that contain only changes to debian/changelog should be dropped.
 
-#### Protip 
+#### Tip 
     
 If you diff your final logical tag against the Ubuntu package it analyses, then the diff should be empty, except:
 1. All changes to debian/changelog: we deliberately exclude these from the logical tag, relying on commit messages instead.

--- a/PackageTests.md
+++ b/PackageTests.md
@@ -3,7 +3,43 @@ Running Package Tests
 
 Packages will have their own tests under `debian/tests`. We need to run those to ensure there are no regressions.
 
-We use autopkgtest to run the tests in a VM or container.
+We can have Launchpad do it against a PPA, or use an LXC container or a VM to run the autopkgtests locally.  Each approach has its benefits, so they're all worth learning, but the first option (PPA-based testing) produces results most similarly to what occurs in the archive itself, so we'll start there.
+
+
+PPA-Based Autopkgtest Testing
+-----------------------------
+
+First, if you haven't already, grab `lp-test-ppa` from the ubuntu-helpers repository:
+
+    $ git clone https://git.launchpad.net/~ubuntu-server/+git/ubuntu-helpers
+    $ ubuntu-helpers/cpaelzer/lp-test-ppa --help
+    usage: lp-test-ppa [-h] ....
+
+Next, you'll need to [set up a PPA and build your package in it](PackageBuilding.md) as described in the "Building Binary Packages via PPA" section.  Once it has built binaries for the architecture(s) you intend to test,
+
+  $ lp-test-ppa --showurl ppa:kstenerud/postfix-postconf-segfault-1753470 --release bionic
+
+This prints to the console a bunch of lines like:
+
+  Using Release Packages ♻️ 
+  http://autopkgtest.ubuntu.com/request.cgi?release=bionic&arch=amd64&package=postfix&ppa=kstenerud/postfix-postconf-segfault-1753470&trigger=postfix/3.3.0-1ubuntu0.1~ppa1
+  http://autopkgtest.ubuntu.com/request.cgi?release=bionic&arch=s390x&package=postfix&ppa=kstenerud/postfix-postconf-segfault-1753470&trigger=postfix/3.3.0-1ubuntu0.1~ppa1
+  ...
+
+The autopkgtest requests require special permissions to run; as a new developer you'll need to ask your co-workers or a coredev to load them.  If you don't know where else to ask, the #ubuntu-devel IRC channel is suitable.  The --showurl parameter causes these URLs to be printed out so they're easier to cut-and-paste into email or chat channels.
+
+Once you've gained permissions to run autopkgtests, though, you can load each of these URLs in your web browser yourself, which will cause the appropriate autopkgtests to run.  If you omit the --showurl parameter, lp-test-ppa will instead display clickable links, making it even more convenient.
+
+After a while, run `lp-test-ppa` again to see how the tests are coming along:
+
+  $ lp-test-ppa ppa:kstenerud/postfix-postconf-segfault-1753470 --release bionic
+  ...
+  Results: (from http://autopkgtest.ubuntu.com/results/.../?format=plain)
+    postfix @ amd64:
+      14.06.22 21:57:01 ✅     Triggers: postfix/3.3.0-1ubuntu0.1~ppa1
+  ...
+
+You can load up the log URLs to see details about why anything failed.
 
 
 Preparing a Testing Image
@@ -37,7 +73,6 @@ Copy the resulting image (autopkgtest-focal-amd64.img) to a common directory lik
     $ autopkgtest-build-lxd images:ubuntu/impish/amd64
 
 You should see an autopkgtest image now when you run `lxc image list`.
-
 
 
 ### Run the Tests


### PR DESCRIPTION
We now have some command line tools to assist in creating PPAs and
running autopkgtests against them.  Include explanations using these
tools.

Don't drop the preexisting documentation doing the processes manually
since they may still be relevant for corner cases that the tools don't
cover, or other situations where a manual approach would be preferred.