### PR TITLE
Remove lintian from package merge instructions

### DIFF
--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -575,11 +575,6 @@ The switches are:
 
 Changes should be from the last ubuntu version
 
-#### Check the built package for errors
-
-    $ lintian --pedantic --display-info --verbose --info --profile ubuntu ../at_3.1.23-1ubuntu1.dsc
-
-
 ### Push to your launchpad repository
 
 Now that the package is tested and builds successfully, it's time to push it to your launchpad repository.


### PR DESCRIPTION
Nowadays, dpkg-buildpackage runs lintian by default anyway.

But either way, what is the package merging person supposed to do with the lintian output? Most of the time, lintian errors that might appear here exist in the Debian packaging already, and we don't typically add Ubuntu delta to remove lintian errors.

It is true that we don't want to *introduce* new lintian errors in an Ubuntu delta, but this is rare too, and it would simplify the instructions just to skip this step.

If someone wants to write instructions to identify only lintian errors introduced by the delta, and check for those, then feel free to do that :-)