### PR TITLE
MergeProposal.md: Change the default reviewer on manual submission

### DIFF
--- a/MergeProposal.md
+++ b/MergeProposal.md
@@ -64,7 +64,7 @@ You'll need to have a branch set up for your package.
    * **Target branch:** The release you are changing the package for, example `ubuntu/bionic-devel`
    * **Commit message:** (leave empty)
    * **Description:** Your merge proposal description
-   * **Reviewer:** `canonical-server`
+   * **Reviewer:** `canonical-server-reporter`
 
  * Click "Propose Merge"
 


### PR DESCRIPTION
Hi!

I noticed that most (if not all) of you use git ubuntu submit for this, but I'm a Miriam of the past (:$) who looks on this page to create a PM on Launchpad (merges or bug fixes, whatever)... so, for the Miriam of the future who might forget the git ubuntu tool and go back to what she learned in her origins in Server Team, I propose this change.

Thank you!