### PR TITLE
PackageTests.md: Added install glance reminder to Canonistack Section

### DIFF
--- a/PackageTests.md
+++ b/PackageTests.md
@@ -128,6 +128,16 @@ $ openstack image list | grep -i arm64 | grep hirsute
 | 1cfeacff-f04a-4bce-ab92-9d8fec7e5edb | ubuntu/ubuntu-hirsute-daily-arm64-server-20201125-disk1.img    | active |
 ```
 
+Make sure that you have installed `glance`. The `nova` script we will use in the following example needs it. 
+You can install it by either using apt: 
+```
+$ sudo apt update && sudo apt install python3-glanceclient
+```
+or pip:
+```
+$ pip install python3-glanceclient
+```
+
 [Finally to run the test on Canonistack](https://wiki.ubuntu.com/ProposedMigration#Reproducing_tests_in_the_cloud) is quite similar to the other invocations. Just two things change compared to "local" autopkgtest-runner invocations.
 
  * `--setup-commands setup-testbed` will have autopkgtest execute `/usr/share/autopkgtest/setup-commands/setup-testbed` on the target which converts any system into a system that is ready for autopkgtest to log in


### PR DESCRIPTION
I followed this Guide and got a `ModuleNotFoundError` for `glance` when I ran the examples with the `nova` script:

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
ModuleNotFoundError: No module named 'glanceclient'
```

`autopkgtest` has no hard dependency to `python3-glanceclient`, because the nova script assumes that it is running in an environment where it is already installed:
```bash
$ head ssh-setup/nova
#!/bin/sh
#
# This script is part of autopkgtest
# autopkgtest is a tool for testing Debian binary packages
#
# This script sets up a nova instance to use as an autopkgtest testbed. It
# assumes that the host system is already prepared to run nova commands.
```

I think it should not be mentioned in the [Setup.md](https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/Setup.md), because this dependency is only needed by people who what to use Canonistack with `autopkgtest`.