### PR TITLE
Update reviewer teams

### DIFF
--- a/BugFixingCheckList.md
+++ b/BugFixingCheckList.md
@@ -103,7 +103,7 @@
      ```
 - [ ]  **6.** MP
     - [ ]  Target Branch: ubuntu/\<UbuntuSeries>-devel for BugFixing or debian/sid for merges
-    - [ ]  Reviewers : canonical-server and  ```$(ubuntu-upload-permission --list-uploaders <package>)```
+    - [ ]  Reviewers : ```$(ubuntu-upload-permission --list-uploaders <package>)``` and `canonical-<your-team> (E.g. `canonical-server-reporter` for server team members)
     - [ ]  Description:
         - [ ]  PPA
         - [ ]  Optional: Tags for merge bugs

--- a/MainInclusion.md
+++ b/MainInclusion.md
@@ -21,6 +21,8 @@ The use of git, instead of just adding and removing the subscriptions in Launchp
 
 ### Process for making changes to the Ubuntu Server Team package subscription list
 
+[Note: This is specific to Ubuntu Server team processes; other teams likely have different processes for maintaining their lists of packages.]
+
 This process is to be used when the [main inclusion process](https://wiki.ubuntu.com/MainInclusionProcess) calls for a package to be subscribed by the Ubuntu Server Team.
 
 The git repository can be found [here](https://git.launchpad.net/~canonical-server/+git/team-subscriptions).
@@ -29,7 +31,7 @@ First, prepare the change locally with a git commit that makes the change. Inclu
 
 If the change is mechanical and uncontroversial, then go ahead and push the change with no merge proposal required. For example, if `php7.2` was already in the list and `php8.0` needs to be added, or if a source package has been split into two with no other significant changes.
 
-If the change fundamentally changes the set of packages that we support from a user perspective, then file a merge proposal for the change, and request a review from `~canonical-server`.
+If the change fundamentally changes the set of packages that we support from a user perspective, then file a merge proposal for the change, and request a review from `~canonical-server-reporter`.
 
 If in doubt, please file a merge proposal anyway.
 

--- a/MergeProposal.md
+++ b/MergeProposal.md
@@ -64,7 +64,7 @@ You'll need to have a branch set up for your package.
    * **Target branch:** The release you are changing the package for, example `ubuntu/bionic-devel`
    * **Commit message:** (leave empty)
    * **Description:** Your merge proposal description
-   * **Reviewer:** `canonical-server-reporter`
+   * **Reviewer:** `canonical-<your-team>` (E.g. `canonical-server-reporter` for server team members)
 
  * Click "Propose Merge"
 
@@ -135,7 +135,7 @@ If a merge proposal should no longer land as-is, you have four options:
 
 1. *Mark it Rejected*. You can do this by changing the Status of the
 merge proposal from near the top left of the Web UI. Doing this will
-remove it from the [Active Reviews page](https://code.launchpad.net/~canonical-server/+activereviews).
+remove it from the [Active Reviews page](https://code.launchpad.net/~canonical-server-reporter/+activereviews).
 
 2. *Force push a replacement*. If the essential topic of the change
 should remain, but the proposed changes be completely replaced, then you

--- a/ProposedMigration.md
+++ b/ProposedMigration.md
@@ -430,7 +430,7 @@ Checkout [https://git.launchpad.net/~ubuntu-release/britney/+git/hints-ubuntu](l
 
 File a MP against it with a description indicating the lp bug#, rationale for why the test can and should be skipped, and explanation of what will be unblocked to migration.
 
-Reviewers should be 'canonical-server', 'ubuntu-release', and any archive admins or foundations team members you've discussed the issue with.
+Reviewers should be 'canonical-<your-team>' (E.g. `canonical-server-reporter` for server team members), 'ubuntu-release', and any archive admins or foundations team members you've discussed the issue with.
 
 
 ## Other Common Issues ##

--- a/Sponsorship.md
+++ b/Sponsorship.md
@@ -19,7 +19,7 @@ For anything non-trivial, it can be a good practice to discuss the change you're
 Finding a Sponsor
 -----------------
 
-There are two formal ways to seek sponsorship.  The first is by filing a Merge Proposal with 'canonical-server' (or other appropriate team) set as a reviewer.  Make sure to mention in your MP comments that you're also in need of sponsorship.  If the reviewer has upload rights they can take care of sponsoring the upload as well.
+There are two formal ways to seek sponsorship.  The first is by filing a Merge Proposal with `canonical-<your-team>` (E.g. `canonical-server-reporter` for server team members) set as a reviewer.  Make sure to mention in your MP comments that you're also in need of sponsorship.  If the reviewer has upload rights they can take care of sponsoring the upload as well.
 
 A second, more traditional approach is to [file a bug report in Launchpad](https://bugs.launchpad.net/ubuntu/+filebug), attach your changes as a [debdiff](http://packaging.ubuntu.com/html/traditional-packaging.html#creating-a-debdiff), and then subscribe *ubuntu-sponsors* (or *ubuntu-security-sponsors* for security issues).  This approach is generally used only if a package is not in git-ubuntu or if a MP can't be generated for some reason.
 


### PR DESCRIPTION
For manually filed reviews, `canonical-server-reporter` should be used now instead of `canonical-server` for the Server Team.

Also, generalize the instructions to direct people to file review requests with their own team, with the Canonical Server team listed only as an example.