### PR TITLE
`sbuild` should not overwrite the `Maintainer:` field of `.changes` files by default

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -250,8 +250,8 @@ Replace the following:
 Template:
 
     # Name to use as override in .changes files for the Maintainer: field
-    # (mandatory, no default!).
-    $maintainer_name='Your Full Name <your@email.com>';
+    # (optional; only uncomment if needed).
+    # $maintainer_name='Your Full Name <your@email.com>';
 
     # Default distribution to build.
     $distribution = "focal";


### PR DESCRIPTION
When I created a change to a package (in my case `inetutils` and `iputils`) the `Maintainer:` field the `.changes` file was overwritten, which was not intended. 

Intended:
```
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Changed-By: Dominik Viererbe <dominik.viererbe@canonical.com>
```

Actual:
```
Maintainer: Dominik Viererbe <dominik.viererbe@canonical.com>
Changed-By: Dominik Viererbe <dominik.viererbe@canonical.com>
```

This resulted in the following `lintian` error:
```
E: iputils changes: inconsistent-maintainer Dominik Viererbe <dominik.viererbe@canonical.com> (changes vs. source) Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
N: 
N:   The Maintainer address in a group of related processables is inconsistent
N:   as indicated.
N:   
N:   This sometimes happens when environmental variables like DEBEMAIL are set
N:   to different values when building sources and changes separately. Please
N:   use the same maintainer everywhere.
N: 
N:   Please refer to Bug#546525, https://wiki.ubuntu.com/DebianMaintainerField,
N:   and Ubuntu Bug#1862787 for details.
N: 
N:   Visibility: error
N:   Show-Always: no
N:   Check: fields/maintainer
```
Commenting out `$maintainer_name` in the `~/.sbuildrc` solved the problem. 

There are valid use cases for this, but I think `sbuild` should not overwrite the `Maintainer:` field of `.changes` files by default.