### PR TITLE
Add documentation triage overview

### DIFF
--- a/BugTriage.md
+++ b/BugTriage.md
@@ -292,8 +292,6 @@ always look at in this meeting:
 Future outlook:
 > as capacity permits we want in the future to start also having
 > a look at the [sponsoring queue](http://reqorts.qa.ubuntu.com/reports/sponsoring/index.html)
-> and (not yet sure if it will be weekly or part of daily triage) look at recent
-> feedback to our documentation using [dsctriage](https://snapcraft.io/dsctriage)
 
 
 ## Awareness of the Triage
@@ -308,7 +306,7 @@ summarizes how many bugs we've triaged and touches on the noteworthy
 cases. This can also be used to CC additional people that (for case
 specific reasons) should be aware of a case.
 An example of that would be if a security fix caused an upgrade-regression
-which would make us CC the uploader and/or ubuntu-security.
+which would make us CC the uploader and/or ubuntu-security. This mail should also contain the relevant information from [documentation triage](DocTriage.md).
 
 Furthermore on cases that need immediate attention or at least awareness
 we might:

--- a/DocTriage.md
+++ b/DocTriage.md
@@ -2,6 +2,23 @@
 
 In order to maintain a line of communication with the community and keep Ubuntu's documentation up to date, doc triage has been added as a task to do during [bug triage](BugTriage.md).
 
+## Tooling
+[Discourse Triage](https://snapcraft.io/dsctriage) is used for working with documentation hosted on Discourse. Documentation for the tool is located on [GitHub](https://github.com/lvoytek/discourse-triage). It can be installed with
+
+    sudo snap install dsctriage
+
+As a part of daily triage, running the base command will show relevant comments for the previous day or over the weekend.
+
+    dsctriage
+
+To run a previous day's triage, provide the relevant date or previous day of the week such as:
+
+    dsctriage 2023-04-27
+
+or
+
+    dsctriage friday
+
 ## Types of Updates
 
 Documentation updates fall into a few categories that require different levels of action. They are:
@@ -40,22 +57,3 @@ Documentation updates fall into a few categories that require different levels o
 
 * Team responses:  
   Responses to community comments by someone on the team will look the same as other comments. In this case, check to make sure the conversation was resolved, and provide extra input if needed.
-
-
-
-## Tooling
-[Discourse Triage](https://snapcraft.io/dsctriage) is used for working with documentation hosted on Discourse. Documentation for the tool is located on [GitHub](https://github.com/lvoytek/discourse-triage). It can be installed with
-
-    sudo snap install dsctriage
-
-As a part of daily triage, running the base command will show relevant comments for the previous day or over the weekend.
-
-    dsctriage
-
-To run a previous day's triage, provide the relevant date or previous day of the week such as:
-
-    dsctriage 2023-04-27
-
-or
-
-    dsctriage friday

--- a/DocTriage.md
+++ b/DocTriage.md
@@ -1,0 +1,61 @@
+# Documentation Triage
+
+In order to maintain a line of communication with the community and keep Ubuntu's documentation up to date, doc triage has been added as a task to do during [bug triage](BugTriage.md).
+
+## Types of Updates
+
+Documentation updates fall into a few categories that require different levels of action. They are:
+
+* New Pages:  
+  When someone creates a new page, which in Discourse is a new Topic under the relevant category, this will show up as a `+` next to the page title and author name. For example:
+
+      +Changing package files [Lena Voytek, 2023-01-11]
+
+  If this shows up, the page should be checked to see if it is a candidate for the official documentation. If so, note this in the report.
+
+* Page Edits:  
+  If a given page has been modified in any way, a `*` will show up alongside the page title and the name of the editor. This looks like:
+
+      *Ubuntu Server tutorials [Sally Makin, 2023-04-12]
+
+  In this case, check what the edit was and note it in the report. If it has any obvious issues, especially if it is a part of the official documentation, make sure to note that too.
+  Also keep in mind when this page was created, as it may need to be triaged as a new post too if it was published within the provided time frame.
+
+* Community comments:  
+  When a community member comments on a page, it will show up with a `+` alongside a link and author name for the comment. A `*` may show up instead if the comment was modified. This line will show up as part of a tree of replies under its given page name.
+  Multiple updates to a conversation may also have happened, such as:
+
+        SSHd now uses socket-base… [Steve Langasek] 
+        ├─ 77972 [Paride Legovini] 
+        │  └─ 80966 [Saxl] 
+        │     └─ 81043 [Leszek A. Szczepanowski] 
+        │        └─ 83849 [Nebulabox] 
+        │           └─ 84773 [Michael Utech] 
+        │              └─ +88070 [Piradix, 2023-04-05] 
+        ├─ +88748 [Dave Ruedeman, 2023-04-19] 
+        └─ +88948 [Darren Embry, 2023-04-23] 
+        └─ *88978 [Steve Langasek, 2023-04-23] 
+
+    Looking through the added and updated comments by clicking the attached links. If a community member has an unanswered question, either reply with the relevant information or note in the report that it needs a reply. For suggestions to change the docs, if they are valid, update the page accordingly or note it down so someone with relevant permissions can do so.
+
+* Team responses:  
+  Responses to community comments by someone on the team will look the same as other comments. In this case, check to make sure the conversation was resolved, and provide extra input if needed.
+
+
+
+## Tooling
+[Discourse Triage](https://snapcraft.io/dsctriage) is used for working with documentation hosted on Discourse. Documentation for the tool is located on [GitHub](https://github.com/lvoytek/discourse-triage). It can be installed with
+
+    sudo snap install dsctriage
+
+As a part of daily triage, running the base command will show relevant comments for the previous day or over the weekend.
+
+    dsctriage
+
+To run a previous day's triage, provide the relevant date or previous day of the week such as:
+
+    dsctriage 2023-04-27
+
+or
+
+    dsctriage friday

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Sections
  * Reviewing
    - [Reviewing Merge Proposals](MergeProposalReview.md)
    - [Bug Triage](BugTriage.md)
+   - [Doc Triage](DocTriage.md)
    - [Bug Report Responses](BugReportResponses.md)
  * Requesting Upload Rights
    - [PackageSet](MembershipInPackageSet.md)


### PR DESCRIPTION
Provide mostly platform-independent instructions for keeping up to date with community interactions with our docs. For now this shows how to do so with dsctriage, but may be expanded for a more overarching "doctriage" tool in the future.