### PR TITLE
Fix missleading use of `groupadd`

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -79,12 +79,12 @@ Then afterwards one can double check group membership via:
     my_user : my_user adm cdrom sudo dip plugdev lpadmin sambashare libvirt sbuild lxd
 ```
 
-If any group is missing for your user one can fix it up via `groupadd` like:
+If any of the following groups is missing for your user you can fix it up via `useradd` like:
 
 ```
-    $ sudo groupadd lxd
-    $ sudo groupadd sbuild
-    $ sudo groupadd libvirt
+    $ sudo adduser my_user lxd
+    $ sudo adduser my_user sbuild
+    $ sudo adduser my_user libvirt
 ```
 
 


### PR DESCRIPTION
This pull request replaces `groupadd` with `adduser` in the setup instructions.

The current description implies that `groupadd` will add the user to the specified groups if the user notices that the output of `groups my_user` does not contain `lxd`, `sbuild` or `libvirt`.
Instead `groupadd` will create these groups, but does not add the user to these groups as described.