### PR TITLE
Setup: remove outdated keygen option

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -272,11 +272,6 @@ SKIP_PROPOSED="1"
 DEBOOTSTRAP_PROXY=http://127.0.0.1:3142/
 ```
 
-Configure GnuPG for SBuild:
-
-```bash
-$ sbuild-update --keygen
-```
 
 > **Note**: 
 > For more info, see the [Ubuntu wiki page on SBuild](https://wiki.ubuntu.com/SimpleSbuild)


### PR DESCRIPTION
Since 0.77 (>=Focal) --keygen does no more exist [1] and it was only needed for very special cases. Our workflow is fine without so we do not even need to add a replacement.

[1]: https://salsa.debian.org/debian/sbuild/-/blob/main/ChangeLog.in#L83