### PR TITLE
Adding Git section, bug reference field and updating section names related to Package Merges

### DIFF
--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -31,26 +31,31 @@ The following template may come useful when submitting reviews:
 
 ```
 * Changelog:
-  - [ ] old content and logical tag match as expected
   - [ ] changelog entry correct version and targeted codename
-  - [ ] changelog entries correct
+  - [ ] correct formatting of changelog's items
+  - [ ] bug references correct
+  - [ ] old content and logical tag match as expected (Package Merge)
+
+* Package Merge - Indirect changes:
+  - [ ] no upstream changes that need adaptation due to Ubuntu's design
+  - [ ] no further upstream version/changes to consider
+  - [ ] debian changes are compatible with the Ubuntu implementation
   - [ ] update-maintainer has been run
 
-* Actual changes:
-  - [ ] no upstream changes to consider
-  - [ ] no further upstream version to consider
-  - [ ] debian changes look safe
-
-* Old Delta:
+* Package Merge - Old Delta:
   - [ ] dropped changes are ok to be dropped
   - [ ] nothing else to drop
   - [ ] changes forwarded upstream/debian (if appropriate)
 
 * New Delta:
   - [ ] no new patches added
-  - [ ] patches match what was proposed upstream
+  - [ ] patches match what was proposed/committed upstream
   - [ ] patches correctly included in debian/patches/series
   - [ ] patches have correct DEP3 metadata
+
+* Git/Maintenance:
+  - [ ] testcases added or not strictly required for this
+  - [ ] commits are properly split (more important on -dev than on SRUs)
 
 * Build/Test:
   - [ ] build is ok


### PR DESCRIPTION
While shadowing Christian on a Patch Pilot session, I realized that he was using a different template for being used in the MP reviews.

I think that template covers more aspects of the review process, so I'm updating it here accordingly.