### PR TITLE
Document autopkgtest cookie extraction and usage

### DIFF
--- a/PackageTests.md
+++ b/PackageTests.md
@@ -49,7 +49,10 @@ cut-and-paste into email or chat channels.
 Once you've gained permissions to run autopkgtests, you can load each of these
 URLs in your web browser yourself, which will cause the appropriate
 autopkgtests to run. If you omit the `--show-url` parameter, `ppa tests` will
-instead display clickable links, making it even more convenient.
+instead display clickable links, making it even more convenient. Alternatively,
+it is possible to [trigger the tests through the command
+line](ProposedMigration.md#triggering-tests-from-the-cli), which is useful when
+you need to trigger several tests.
 
 After a while, run `ppa tests` again to see how the tests are coming along:
 

--- a/ProposedMigration.md
+++ b/ProposedMigration.md
@@ -684,7 +684,7 @@ the test URL. If that passes, but the package still does not migrate, then look
 in the test log for all packages that were pulled from -proposed and include
 those as triggers.
 [Excuses Kicker](https://git.launchpad.net/~bryce/+git/excuses-kicker) and
-[retry-autopkgtest-regressions](https://bazaar.launchpad.net/~ubuntu-archive/ubuntu-archive-tools/trunk/view/head:/retry-autopkgtest-regressions)
+[retry-autopkgtest-regressions](https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions)
 are handy tools for generating these URLs.
 
 As with rebuilds, these re-triggers also require Core Dev permissions, so if


### PR DESCRIPTION
This change was based on the comments available in the retry-autopkgtest-regressions script at https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions