### PR TITLE
version-strings: add details around first SRU inclusion of patches

### DIFF
--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -86,13 +86,13 @@ After a version of Ubuntu is released, changes to packages follow a slightly dif
 The overall scheme stays the same for [Stable release updates](https://wiki.ubuntu.com/StableReleaseUpdates). One still only changes the _ubuntu revision_ section of `[upstream_version]-[debian_revision]ubuntu[ubuntu_revision]`.
 
 * Increment Y in the numeric `ubuntuX.Y` suffix, like: `ubuntu3.1 -> ubuntu3.2`.
-* If this is the first change via the SRU process, add the `.1` suffix, like: `ubuntu3 -> ubuntu3.1`.
+* If this is the first changeset via the SRU process, add the `.1` suffix, like: `ubuntu3 -> ubuntu3.1`.
 * If no `ubuntuX` was present before, then set `ubuntu0.1` which will represent that there was no Ubuntu delta (`0`) before this upload which is the first to add a change (`.1`).
 * If two releases have the same version, then this would make the package non upgradeable and cause a version conflict (two builds, but not the same). To resolve this, add the numeric `YY.MM` release version in between `ubuntuX` and the increment `.1`. For Jammy that might look like `...ubuntu3.22.04.1`
 
 Compare these examples with the _[adding a change in the current Ubuntu development release](VersionStrings.md#version-adding-a-change-in-the-current-ubuntu-development-release)_ section above to better see the subtle difference.
 
-> Example in detail: _Adding a change to `2.0-2` in a stable Ubuntu release will use `2.0-2ubuntu0.1`_
+> Example in detail: _Adding a change to `2.0-2` in a stable Ubuntu release will use `2.0-2ubuntu0.1`. This first .1 change must include any supplemental debian packaging changes or patches applicable to the stable release for this first SRU._
 
 > Example in detail: _Adding another change to `2.0-2ubuntu0.1` in a stable Ubuntu release will use `2.0-2ubuntu0.2`_
 


### PR DESCRIPTION
For SRUs which are a new upstream snapshot into a stable release, the first SRU may require supplemental debian packaging changes such as quilt patches to alter the downstream behavior of that snapshot.

In the case where backports or patches are required as the first SRU, it is important to note that we prefer the make use of the version .1 instead of promoting the version to .2 to indicate additional packaging changes beyond the upstream snapshot involved in this SRU.

Fixes GH-97



- context

Looking for input on how best to capture that all changes in an initial SRU can and should include any backports or quilt patches in this first SRU version suffix `.1` to avoid feeling the compulsion to use a `.2` on the first downstream SRU to indicate that the upstream snapshot also includes additional downstream behavioral changes.

cloud-init SRU process typically performs an upstream snapshot but may also add downstream quilt patches to alter certain behavior of that snapshot on stable releases. Historically, if quilt patches were involved in the SRU we had bumped the patch version to .2 to indicate that there are supplemental downstream patches applied as delta to differentiate from other stable releases which carry the same version prefix.  Providing this additional guidance that `.1` should always be used and must include any packaging changes helps us establish a policy that you always use `.1` regardless of any supplemental backports or patches that may be required for this first SRU.