### PR TITLE
Update Setup.md to replace reference to snapcraft deb

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -36,11 +36,11 @@ sudo apt install -y \
     qemu-system \
     quilt \
     sbuild \
-    snapcraft \
     ubuntu-dev-tools \
     uvtool \
     virtinst && \
 sudo snap install lxd && \
+sudo snap install snapcraft && \
 sudo snap install --classic ustriage && \
 sudo snap install --classic --edge git-ubuntu && \
 sudo snap install --classic --beta multipass


### PR DESCRIPTION
The snapcraft deb is no longer supported and even fails to install on some systems:

https://bugs.launchpad.net/ubuntu/+source/snapcraft/+bug/2039454