### PR TITLE
version-strings: Make wording more succinct and explicit          

### DIFF
--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -79,22 +79,23 @@ List of this and further related examples:
 | 2.1-1        | 2.1-1ubuntu2         | _unchanged_    | 3.1          | 3.1-0ubuntu1          |
 | 2.1-1        | 2.1-1ubuntu2         | _unchanged_    | 2.3          | 2.3-0ubuntu1          |
 
-## Version: Adding a change in Ubuntu as a stable release update
+## Version: Adding a change in Ubuntu as a [stable release update](https://wiki.ubuntu.com/StableReleaseUpdates)
 
 After a version of Ubuntu is released, changes to packages follow a slightly different versioning scheme which ensures upgradability to later releases and allows the history of changes to be recognized from just looking at the version.
 
-The overall scheme stays the same for [Stable release updates](https://wiki.ubuntu.com/StableReleaseUpdates). One still only changes the _ubuntu revision_ section of `[upstream_version]-[debian_revision]ubuntu[ubuntu_revision]`.
+The only change from the normal ubuntu version scheme is to the _ubuntu revision_ section of `[upstream_version]-[debian_revision]ubuntu[ubuntu_revision]`.
 
 * Increment Y in the numeric `ubuntuX.Y` suffix, like: `ubuntu3.1 -> ubuntu3.2`.
+* Never increment X in the numeric `ubuntuX.Y` suffix. An Ubuntu delta is always captured in Y.
 * If this is the first change via the SRU process, add the `.1` suffix, like: `ubuntu3 -> ubuntu3.1`.
 * If no `ubuntuX` was present before, then set `ubuntu0.1` which will represent that there was no Ubuntu delta (`0`) before this upload which is the first to add a change (`.1`).
 * If two releases have the same version, then this would make the package non upgradeable and cause a version conflict (two builds, but not the same). To resolve this, add the numeric `YY.MM` release version in between `ubuntuX` and the increment `.1`. For Jammy that might look like `...ubuntu3.22.04.1`
 
 Compare these examples with the _[adding a change in the current Ubuntu development release](VersionStrings.md#version-adding-a-change-in-the-current-ubuntu-development-release)_ section above to better see the subtle difference.
 
-> Example in detail: _Adding a change to `2.0-2` in a stable Ubuntu release will use `2.0-2ubuntu0.1`_
+> Example in detail: _Adding a change to `2.0-2` in an Ubuntu stable release update will use `2.0-2ubuntu0.1`.
 
-> Example in detail: _Adding another change to `2.0-2ubuntu0.1` in a stable Ubuntu release will use `2.0-2ubuntu0.2`_
+> Example in detail: _Adding an Ubuntu delta to `2.0-2ubuntu2.4` in an Ubuntu stable release update will use `2.0-2ubuntu2.5`_
 
 List of these and further related examples:
 

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -95,7 +95,7 @@ Compare these examples with the _[adding a change in the current Ubuntu developm
 
 > Example in detail: _Adding a change to `2.0-2` in an Ubuntu stable release update will use `2.0-2ubuntu0.1`.
 
-> Example in detail: _Adding an Ubuntu delta to `2.0-2ubuntu2.4` in an Ubuntu stable release update will use `2.0-2ubuntu2.5`_
+> Example in detail: _Adding an Ubuntu delta to `2.0-2ubuntu2.4` in an Ubuntu stable release update will use `2.0-2ubuntu2.5`.
 
 List of these and further related examples:
 

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -93,9 +93,9 @@ The only change from the normal ubuntu version scheme is to the _ubuntu revision
 
 Compare these examples with the _[adding a change in the current Ubuntu development release](VersionStrings.md#version-adding-a-change-in-the-current-ubuntu-development-release)_ section above to better see the subtle difference.
 
-> Example in detail: _Adding a change to `2.0-2` in an Ubuntu stable release update will use `2.0-2ubuntu0.1`.
+> Example in detail: Adding a change to `2.0-2` in an Ubuntu stable release update will use `2.0-2ubuntu0.1`.
 
-> Example in detail: _Adding an Ubuntu delta to `2.0-2ubuntu2.4` in an Ubuntu stable release update will use `2.0-2ubuntu2.5`.
+> Example in detail: Adding an Ubuntu delta to `2.0-2ubuntu2.4` in an Ubuntu stable release update will use `2.0-2ubuntu2.5`.
 
 List of these and further related examples:
 


### PR DESCRIPTION
version-strings: Make wording more succinct and explicit                            
                                                                                    
Current wording states that Stable Release Updates have a different                 
scheme in the "ubuntu revision" section of the version scheme, but does             
not explicitly state that the details in this section completely override           
other guidance in other sections of the handbook regarding "ubuntu revisions".          
                                                                                    
Previous wording leaves unclear whether an Ubuntu-specific delta released in a          
Stable Release Update should increment a) the Ubuntu delta number (ubuntuN),          
which remains part of the "ubuntu revisions" section, or b) the "increment" in          
the Stable Release Updates version string.                                          
                                                                                    
Also make other wording in this section more direct.                                
                                                                                    
Fixes #97                     