### PR TITLE
Avoid referring to a stale local branch

### DIFF
--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -1234,7 +1234,7 @@ git ubuntu merge -f start
 rm .git/hooks/pre-commit
 
 # finish the merge
-git ubuntu merge finish pkg/ubuntu/devel debian/sid
+git ubuntu merge finish pkg/ubuntu/devel
 
 #... Create MP as usual, get reviewed/approved, etc. ...
 

--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -175,7 +175,13 @@ result: https://bugs.launchpad.net/ubuntu/+source/at/+bug/1802914
 > **Save the bug report number, because you'll be using it throughout the merge
 > process.**
 
-### Clone the package repository
+### Get the package repository
+
+If not yet present, cloning the repository is the start of all further
+interaction. If instead the repository is already present, update it to
+ensure to have the newest content before any further action.
+
+#### Clone the package repository
 
 ```bash
 git ubuntu clone <package> [<package>-gu]
@@ -190,6 +196,16 @@ $ git ubuntu clone at at-gu
 It's a good idea to append some `git-ubuntu` specific label (like `-gu`) to
 distinguish it from clones of Debian or upstream git repositories (which tend
 to want to clone as the same name).
+
+#### Update the package repository
+
+Since this is just git, the best way to update the git ubuntu based content
+as well as any other potentially added further remotes is to just update
+them all before going into the merge process.
+
+```bash
+$ git fetch --all
+```
 
 ## The merge process
 

--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -198,7 +198,7 @@ to want to clone as the same name).
 From within the git source tree:
 
 ```bash
-git ubuntu merge start ubuntu/devel
+git ubuntu merge start pkg/ubuntu/devel
 ```
 
 This will generate the following tags for you:
@@ -682,7 +682,7 @@ described below.
 ### Finish the merge
 
 ```bash
-$ git ubuntu merge finish ubuntu/devel
+$ git ubuntu merge finish pkg/ubuntu/devel
 ```
 
 If this fails, [do it manually](#finish-the-merge-manually).

--- a/PackageMerging.md
+++ b/PackageMerging.md
@@ -752,7 +752,7 @@ then the diff should be empty, except:
 1. `rmadison -u debian <package_name>`
 1. `git ubuntu clone <package_name> <package_name>-gu`
 1. `cd <package_name>-gu`
-1. `git ubuntu merge start ubuntu/devel`
+1. `git ubuntu merge start pkg/ubuntu/devel`
 1. `git checkout -b
 merge-<version_of_debian_unstable>-<current_ubuntu_devel_name>`
 1. `git log --stat old/debian..`
@@ -766,7 +766,7 @@ straight away
 1. `git rebase -i --onto new/debian old/debian`
 1. `quilt push -a --fuzz=0`
 1. `quilt pop -a`
-1. `git ubuntu merge finish ubuntu/devel`
+1. `git ubuntu merge finish pkg/ubuntu/devel`
 
 ## Upload a PPA
 


### PR DESCRIPTION
ubuntu/devel might be a local branch and that might have gotten out of date. People could waste time until they spot to work on the wrong version.

Instead refer to the pkg remote which is the latest state of the importer and should always be a better choice for merge start/finish.