### PR TITLE
Change remote when creating container with autopktest-build-lxd

### DIFF
--- a/PackageTests.md
+++ b/PackageTests.md
@@ -112,7 +112,7 @@ First, we will build the image we prepared in the previous section.
 * To build a container image:
 
   ```bash
-  $ autopkgtest-build-lxd images:ubuntu/impish/amd64
+  $ autopkgtest-build-lxd ubuntu-daily:oracular
   ```
 
   You should see an autopkgtest image now when you run `lxc image list`.


### PR DESCRIPTION
`images:` remote doesn't provide Ubuntu Server images anymore (as seen on MM at https://chat.canonical.com/canonical/pl/gkqq68hbq7bo7ge1jkc8jim8xc).