### PR TITLE
Fix italic formatting and a broken link

### DIFF
--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -184,7 +184,7 @@ List of this and further related examples:
 It is unlikely, but possible that one needs a no change rebuild as part of a [Stable release update](https://canonical-sru-docs.readthedocs-hosted.com),
 but in this situation auto-syncing isn't active anyway and the need for upgradability applies.
 So a no-change-rebuild in regard to picking a version number in this case is identical to any other change
-(see the section _(adding a change in Ubuntu as a stable release update)[VersionStrings.md#version-adding-a-change-in-ubuntu-as-a-stable-release-update]_ above).
+(see the section _[adding a change in Ubuntu as a stable release update](VersionStrings.md#version-adding-a-change-in-ubuntu-as-a-stable-release-update)_ above).
 
 
 ## Version: Backport from upstream

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -121,7 +121,7 @@ Due to that in a Debian native package, there is no `-debian_revision`.
 
 This continues into native Ubuntu packages, which have neither `-debian_revision` nor `ubuntu[ubuntu_revision]`.
 
-> Example in detail: _A package native to Debian `2.0` (no `-`), getting an Ubuntu change in the devel release would use `2.0ubuntu1`
+> Example in detail: _A package native to Debian `2.0` (no `-`), getting an Ubuntu change in the devel release would use `2.0ubuntu1`_
 
 Furthermore native package versioning is package dependent; whether if it uses only _major_, or a _major.minor_, or any other version pattern is the maintainer's choice.
 Just as usually upstream can and will version software the way they consider the best.


### PR DESCRIPTION
* fix closing `_` marker for an italic sentence
* fix link to `VersionStrings.md#version-adding-a-change-in-ubuntu-as-a-stable-release-update` by fixing the markdown syntax