### PR TITLE
MergeProposalReview.md: changes can be in debian/*

### DIFF
--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -94,13 +94,18 @@ N = not applicable to this case
 * Package Merge - old delta:
   - [ ] Dropped changes are ok to be dropped
   - [ ] Nothing else to drop
-  - [ ] Changes forwarded upstream/Debian (if appropriate)
+  - [ ] Old delta was forwarded to upstream/Debian or marked as Ubuntu-only
 
-* New delta:
+* New delta in debian/*:
+  - [ ] new changes in debian/* are OK
+  - [ ] New delta was forwarded to Debian or marked as Ubuntu-only
+
+* New patches:
   - [ ] No new patches added
   - [ ] Patches match those proposed/committed upstream
   - [ ] Patches correctly included in Debian/patches/series
   - [ ] Patches have correct DEP-3 metadata
+  - [ ] New code not from upstream was forwarded or marked as Ubuntu-only
 
 * Git/maintenance:
   - [ ] Commits are properly split (more important on -dev than on SRUs)


### PR DESCRIPTION
We haven't had a good place to raise/discuss/ensure things about changes in debian/* not being patches in d/p/*
Furthermore we only asked for upstreaming in some of those places, but the target of upstreaming differs and furthermore we lacked expressing that it is ok to mark things as Ubuntu-only if that is the right state for this delta.
This PR fixes all that in the review template to make reviews easier and more complete.