### PR TITLE
Favor descriptive commit messages

### DIFF
--- a/CommittingChanges.md
+++ b/CommittingChanges.md
@@ -188,7 +188,7 @@ Simply run `dch` from inside the repository and follow the instructions.
 ## Commit the changelog
 
 ```bash
-$ git commit -m changelog debian/changelog
+$ git commit -m "Update changelog" debian/changelog
 ```
 
 


### PR DESCRIPTION
The commit message for updating changelogs in package merges is documented as being just "changelog". Those messages are irrelevant during the merges, given the commits touching d/changelog are dropped during the merge process.

Commits touching d/changelog for a package release should be more descriptive by default to match the messages touching d/control when updating the Maintainer field.