### PR TITLE
Describe git-buildpackage patch-queue based patch format

### DIFF
--- a/DebianPatch.md
+++ b/DebianPatch.md
@@ -123,6 +123,14 @@ the following pattern for the file name emerged:
 debian/patches/lp-<bugnumber>-<patchindex>-<description>.patch`
 ```
 
+Alternatively, a `lp<bugnumber>/<patchindex>-<description>.patch` format can be
+used, as supported by automated tooling, such as git-buildpackage patch-queue.
+To do that add the following `gbp pq` pseudo header into you patch-queue
+commits:
+```
+Gbp-Pq: Topic lp<bugnumber>
+```
+
 The one case where this naming scheme can be harmful is that you'd usually
 not want to upstream this file name to Debian as the launchpad bug does
 not mean much there.


### PR DESCRIPTION
Describe git-buildpackage patch-queue based patch naming scheme for distro patches.

E.g. using this pseudo-header inside the git-buildpackage patch-queue commits (after running `gbp pq switch`, before running `gbp pq export`).

```
Gbp-Pq: Topic lp<bugnumber>
```