### PR TITLE
Version page clarifications for development releases

### DIFF
--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -15,6 +15,7 @@ When we modify a package compared to what's shipped by Debian, we indicate the c
 One can think of a Ubuntu version number consisting of three components:
 `[upstream_version]-[debian_revision_component]ubuntu[ubuntu_revision_component]`.
 The `ubuntu` string then marks that whatever follows it is related to changes added in Ubuntu.
+(`ubuntu` isn't the only string used here, but more on that shortly.)
 
 This distinction allows each party involved in providing a package to the users — Upstream, Debian and Ubuntu — to modify and iterate on their section of the version number without interfering with others.
 When everyone abides by these conventions we can guarantee package upgradability, but also allow that one can understand some of the package history by just looking at the package version.
@@ -27,23 +28,29 @@ Changes within the development release require adding or incrementing the number
 Consequently, the first Ubuntu modification would have `ubuntu1` appended to the Debian revision.
 Subsequent Ubuntu changes would increment this suffix, i.e. `ubuntu1 -> ubuntu2`.
 
-Finally if formerly there has already been one (or many) _no change rebuilds_ there might be a `buildX` suffix which is in this case replaced by `ubuntu1`.
-More about this in the later section about _[no change rebuilds](VersionStrings.md#version-no-change-rebuilds)_.
-
 > Example in detail: _Adding a change to `2.0-2` in the Ubuntu development release will use `2.0-2ubuntu1`_
 
 > Example in detail: _Adding another change to `2.0-2ubuntu1` in the Ubuntu development release will use `2.0-2ubuntu2`_
 
-List of these and further related examples:
+As alluded to earlier, there are a number of special cases, and situations where we use a string other than `ubuntu` in Ubuntu version numbers.
+One such case is `build`, typically used for _[no change rebuilds](VersionStrings.md#version-no-change-rebuilds)_ that will be discussed in more depth below.
+The key thing to know when incrementing from a `buildN` is that the package is considered unchanged from the debian revision component, and incremented as a *new* Ubuntu change.
 
-| Previous version             | Recommended version   |
-| ---------------------------- | --------------------- |
-| 2.0-2                        | 2.0-2ubuntu1          |
-| 2.0-2ubuntu1                 | 2.0-2ubuntu2          |
-| 2.0-2ubuntu2                 | 2.0-2ubuntu3          |
-| 2.0-2build2                  | 2.0-2ubuntu1          |
+Here's a listing of examples of the application of these rules:
 
-Note: While being the common case, please consider reading further about more special cases which can lead to different results.
+| Previous version             | Modification type | Recommended version   |
+| ---------------------------- | ----------------- | --------------------- |
+| 2.0-2                        | Ubuntu change     | 2.0-2ubuntu1          |
+| 2.0-2ubuntu1                 | Ubuntu change     | 2.0-2ubuntu2          |
+| 2.0-2ubuntu2                 | Ubuntu change     | 2.0-2ubuntu3          |
+| 2.0-3                        | Re-Sync w/ Debian | 2.0-3                 |
+| 2.0-3                        | No-change rebuild | 2.0-3build1           |
+| 2.0-3build1                  | No-change rebuild | 2.0-3build2           |
+| 2.0-3build2                  | Ubuntu change     | 2.0-3ubuntu1          |
+
+While these examples cover common scenarios, it's important to note that they apply specifically to the current Ubuntu development release.
+Stable releases have different policies, but first we'll explore some special cases for development releases.
+
 
 ## Version: Merging from Debian
 

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -1,29 +1,31 @@
 Version string format
 =====================
 
-Selecting the right [version](https://manpages.ubuntu.com/manpages/man7/deb-version.7.html)
-can be quite complex as there are many conditions that need to be considered.
-The following paragraphs first link to the required basics, which are shared with Debian.
-Then each paragraph explains situations that might occur in an upload to Ubuntu.
+Choosing the appropriate [version](https://manpages.ubuntu.com/manpages/man7/deb-version.7.html) can be complex due to numerous conditions to consider. The following paragraphs first provide links to essential foundational information, shared with Debian. Subsequently, each paragraph addresses specific scenarios that may arise when uploading to Ubuntu.
+
 
 ## The Version field
 
-While Debian docs won't include Ubuntu specificities, it is helpful to fully read through [Debian control field "Version"](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version) for overall topic awareness.
+Since Ubuntu's versioning specifics are derived from Debian, it is beneficial to begin by thoroughly reviewing the
+[Debian control field "Version"](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version)
+to understand the foundational principles.
+The key takeaway is that Debian versions are formatted as `[upstream_version]-[debian_revision]`, using the `-` to split the upstream version from the Debian packaging revision.
 
-When Ubuntu adds a change or modification on top on what is in Debian, that change is expressed in the version number.
-One can think of a version number consisting of three segments: `[upstream_version]-[debian_revision]ubuntu[ubuntu_revision]`.
-The `-` splits the upstream version from the Debian packaging segment as you have seen in [Debian control field "Version"](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version).
+When we modify a package compared to what's shipped by Debian, we indicate the change by adding 'ubuntu' to the Debian revision.
+One can think of a Ubuntu version number consisting of three components:
+`[upstream_version]-[debian_revision_component]ubuntu[ubuntu_revision_component]`.
 The `ubuntu` string then marks that whatever follows it is related to changes added in Ubuntu.
 
 This distinction allows each party involved in providing a package to the users — Upstream, Debian and Ubuntu — to modify and iterate on their section of the version number without interfering with others.
-When everyone abides by these conventions we can guarantee package upgradability, but also allow that one can derive a lot of the history by just looking at the package version.
+When everyone abides by these conventions we can guarantee package upgradability, but also allow that one can understand some of the package history by just looking at the package version.
+
 
 ## Version: Adding a change in the current Ubuntu development release
 
 As shown above `[upstream_version]-[debian_revision]ubuntu[ubuntu_revision]` is the basic pattern.
-Changes in the development release will always add or increment the number that directly follows the `ubuntu` string.
-Therefore, if this is the first Ubuntu change, one would append `ubuntu1` as an Ubuntu suffix.
-If there was already an Ubuntu change, one would increment the suffix like `ubuntu1 -> ubuntu2`.
+Changes within the development release require adding or incrementing the number immediately following the `ubuntu` string.
+Consequently, the first Ubuntu modification would have `ubuntu1` appended to the Debian revision.
+Subsequent Ubuntu changes would increment this suffix, i.e. `ubuntu1 -> ubuntu2`.
 
 Finally if formerly there has already been one (or many) _no change rebuilds_ there might be a `buildX` suffix which is in this case replaced by `ubuntu1`.
 More about this in the later section about _[no change rebuilds](VersionStrings.md#version-no-change-rebuilds)_.

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -52,6 +52,27 @@ While these examples cover common scenarios, it's important to note that they ap
 Stable releases have different policies, but first we'll explore some special cases for development releases.
 
 
+## Version: Syncing from Debian
+
+Sometimes the desired change has already been packaged by Debian in a newer version of the package.
+
+During the Ubuntu development cycle, the archive tooling automatically copy or '[sync](Syncs.md#why-a-sync-is-better)' new package versions from Debian.
+Only packages with no Ubuntu modifications or those with no-change updates (i.e., versions with `build` rather than `ubuntu` in the revision), are automatically synced.
+If these updates pass Ubuntu's automated testing, they do not require manual intervention.
+However, there are scenarios where the automation cannot handle the process.
+
+First, once the development release reaches [Debian import freeze](https://wiki.ubuntu.com/DebianImportFreeze), the sync automation is disabled.
+Therefore, if an update from Debian *is* required, it must be [manually synced](Syncs.md).
+Version numbering in this case is trivial:  It's the exact same version as in Debian.
+
+A second case is when the package does have Ubuntu changes,
+but our modifications no longer need to be carried as Ubuntu delta with the new Debian package.
+For example, perhaps the Ubuntu changes were cherrypicked patches from upstream that are now available in a newer release now available from Debian,
+or perhaps Debian has adopted all of the Ubuntu changes into their own packaging.
+These situations will also require a [manual re-sync with Debian](Syncs.md).
+The version number also remains identical to Debian (see the 'Re-Sync w/ Debian' example in the previous section).
+
+
 ## Version: Merging from Debian
 
 If Ubuntu has delta to the package from Debian, it can not be

--- a/VersionStrings.md
+++ b/VersionStrings.md
@@ -73,6 +73,44 @@ These situations will also require a [manual re-sync with Debian](Syncs.md).
 The version number also remains identical to Debian (see the 'Re-Sync w/ Debian' example in the previous section).
 
 
+## Version: No-change Rebuilds
+
+Sometimes a package has previously successfully synced into Ubuntu, and still does not require changes to the packaging or source code,
+but the generated binaries *do* require rebuilding against newer versions of dependencies.
+A common example of this is a library being updated to a newer ABI,
+such that a package depending on it needs re-linked in order to continue functioning properly.
+(The process of updating packages dependent on a changed library like this is called a ["transition"](Transitions.md).)
+
+Rebuilding is not considered a change that should prevent future syncing, so in this special case one would:
+
+* Not add `ubuntuX` and instead add a `buildX` suffix.
+* If there is already one such `buildX` suffix present, increment it.
+* If there is already an `ubuntuX` suffix there would be no auto-sync anyway, so increment the existing suffix.
+
+So far it is weakly defined if a no change rebuild for _[native packages](VersionStrings.md#version-native-packages)_ shall be a version increment or adding a `buildX` suffix.
+Both styles are present in the archive and both will work just fine.
+Until this is properly defined one should try to follow what the particular package used so far.
+
+> Example in detail: _A Debian package `2.0-2` needs a rebuild in Ubuntu which would use `2.0-2build1`_
+
+List of this and further related examples:
+
+| Previous version             | No change rebuild in devel    |
+| ---------------------------- | ----------------------------- |
+| 2.0-2                        | 2.0-2build1                   |
+| 2.0-2ubuntu2                 | 2.0-2ubuntu3                  |
+| 2.0-2build1                  | 2.0-2build2                   |
+| 2.0 (native in Ubuntu)       | 2.1 or 3 or 2.0build1         |
+| 2   (native in Ubuntu)       | 3 or 2build1                  |
+| 2.0 (native in Debian)       | 2.0build1                     |
+| 2   (native in Debian)       | 2build1                       |
+
+It is unlikely, but possible that one needs a no change rebuild as part of a [Stable release update](https://canonical-sru-docs.readthedocs-hosted.com),
+but in this situation auto-syncing isn't active anyway and the need for upgradability applies.
+So a no-change-rebuild in regard to picking a version number in this case is identical to any other change
+(see the section _[adding a change in Ubuntu as a stable release update](VersionStrings.md#version-adding-a-change-in-ubuntu-as-a-stable-release-update)_ above).
+
+
 ## Version: Merging from Debian
 
 If Ubuntu has delta to the package from Debian, it can not be
@@ -174,47 +212,6 @@ List of these and further related examples:
 | 2.0build2              | 2.0ubuntu1    |  2.0ubuntu0.1 |
 
 Note: The rule of multiple releases having the same version requiring to add also a per-release YY.MM to differentiate and ensure upgradability might apply here as well.
-
-## Version: no change rebuilds
-
-Ubuntu continuously [syncs](Syncs.md#why-a-sync-is-better) changes from Debian
-until the [Debian import freeze](https://wiki.ubuntu.com/DebianImportFreeze) date is met, then syncs are deactivated to stabilize the upcoming Ubuntu release.
-As outlined in these references there _"will be automatically imported from Debian where they have not been customized for Ubuntu, that is when the version number of the
-package in the current Ubuntu development branch does not contain the substring ubuntu"_.
-
-And as we learned in _[Adding a change in the current Ubuntu development release](VersionStrings.md#version-adding-a-change-in-the-current-ubuntu-development-release)_
-above adding a change in Ubuntu will add a `ubuntuX` suffix, which prevents the automatic synchronisation process, which thereby will ensure Ubuntu is not unintentionally losing these changes.
-
-But what if one needs to rebuild a package as-is, for example due to a library transition to build against new versions of other packages,
-but does not want to prevent future automatic syncing of new versions from Debian?
-Well, just rebuilding is not considered a change that has to be retained, so in this special case one would:
-
-* Not add `ubuntuX` and instead add a `buildX` suffix.
-* If there is already one such `buildX` suffix present, increment it.
-* If there is already an `ubuntuX` suffix there would be no auto-sync anyway, so increment the existing suffix.
-
-So far it is weakly defined if a no change rebuild for _[native packages](VersionStrings.md#version-native-packages)_ shall be a version increment or adding a `buildX` suffix.
-Both styles are present in the archive and both will work just fine.
-Until this is properly defined one should try to follow what the particular package used so far.
-
-> Example in detail: _A Debian package `2.0-2` needs a rebuild in Ubuntu which would use `2.0-2build1`_
-
-List of this and further related examples:
-
-| Previous version             | No change rebuild in devel    |
-| ---------------------------- | ----------------------------- |
-| 2.0-2                        | 2.0-2build1                   |
-| 2.0-2ubuntu2                 | 2.0-2ubuntu3                  |
-| 2.0-2build1                  | 2.0-2build2                   |
-| 2.0 (native in Ubuntu)       | 2.1 or 3 or 2.0build1         |
-| 2   (native in Ubuntu)       | 3 or 2build1                  |
-| 2.0 (native in Debian)       | 2.0build1                     |
-| 2   (native in Debian)       | 2build1                       |
-
-It is unlikely, but possible that one needs a no change rebuild as part of a [Stable release update](https://canonical-sru-docs.readthedocs-hosted.com),
-but in this situation auto-syncing isn't active anyway and the need for upgradability applies.
-So a no-change-rebuild in regard to picking a version number in this case is identical to any other change
-(see the section _[adding a change in Ubuntu as a stable release update](VersionStrings.md#version-adding-a-change-in-ubuntu-as-a-stable-release-update)_ above).
 
 
 ## Version: Backport from upstream


### PR DESCRIPTION
I've worked on revising the Versions page.  Mostly this is copyediting and revisions to improve clarity and readability, but I've added some more substantive changes regarding syncing, and moved up the section on no-change rebuilds.  I figure covering all the trivial situations first would get them out of the way.
