### PR TITLE
Small fixes for "Package Building" article

### DIFF
--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -244,7 +244,7 @@ Launchpad also sends "status updates" notification mails, so monitor your
 inbox.
 
 
-## Build binary packages locally with `sbuild
+## Build binary packages locally with `sbuild`
 
 Assuming you [have configured `sbuild` properly](Setup-md#sbuild),
 you can use it to build the binary package. Usually you'd want to specify

--- a/PackageBuilding.md
+++ b/PackageBuilding.md
@@ -42,7 +42,7 @@ Let us list the arguments used here
 * -I = --tar-ignore - for the created tarball, without arguments it will add default exclude options to filter out unwanted files
 * -i = --diff-ignore - for the diff, without arguments it will add default exclude options to filter out unwanted files
 * -nc = --no-pre-clean - do not clean the tree before building
-* -d = --no-pre-clean - Do not check build dependencies and conflicts, ok as we only build the source
+* -d = --no-check-builddeps - Do not check build dependencies and conflicts, ok as we only build the source
 
 When based on git-ubuntu branch and going for an upload to the Ubuntu Archive
 please also add the output of `git ubuntu prepare-upload args` which will add


### PR DESCRIPTION
Just two little fixes to errors I found whilst reading through the "Package Building" page:
1. The long name of the `-d` flag of `dpkg-buildpackage` was `--no-pre-clean` instead of `--no-check-builddeps`
2. The Markdown backticks for `sbuild` weren't closed in the "Build binary packages locally with `sbuild`" title