### PR TITLE
Improve feedback guidance

### DIFF
--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -25,9 +25,9 @@ Therefore, we acknowledge that we have two kinds of changes we might propose:
 * Changes are trivial:
   * The requester is only looking for a second pair of eyes for lapses that might have happened unaware and unintentionally. But not after a deeper check as we'd usually do.
   * In this case the requester shall mark the proposal by stating **Trivial change** in the description.
-  * Depending on the case that might also lift some other common practice we have, like pre-building in PPA and pre-testing autopkgtest against it.
   * In this case the review can be free form and rather short.
   * But if the reviewer has a hunch or disagrees with that classification they are entitled to do a full pass.
+  * Depending on the case such trivial changes can also free from further, otherwise required, practice that we have. Like pre-building in PPA and pre-testing autopkgtest against it.
 
 ### States for each template entry
 

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -4,13 +4,17 @@ We established a review process before sponsoring or uploading content, which
 has helped us maintain consistently high quality.
 To do so we propose our changes as [merge proposals against `git-ubuntu` branches](MergeProposal.md).
 
+## What we review
+
 In this review, we:
 * Review formal content for issues
 * Ensure adherence to team style guidelines
 * Identify common issues
 * Conduct further testing (when warranted)
 
-The following states indicate reviewer feedback on each aspect we want to check.
+## States for each template entry
+
+The following states indicate reviewer feedback on each aspect we check.
 
 * *OK* - This was checked and there was nothing of concern to be raised.
 * *Not OK* - Something is not as it should be and needs to be changed in the proposed content.

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -19,7 +19,7 @@ sometimes a proposal can be rather trivial.
 And while we love the rigor we have established and holding each other
 accountable to it, we also hate inefficiency.
 
-Therefore, we acknoledge that we have two kinds of changes we might propose:
+Therefore, we acknowledge that we have two kinds of changes we might propose:
 * Changes are complex or there is any kind of remaining uncertainty
   * Full review please as outlined below (the default)
 * Changes are trivial:

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -4,7 +4,15 @@ We established a review process before sponsoring or uploading content, which
 has helped us maintain consistently high quality.
 To do so we propose our changes as [merge proposals against `git-ubuntu` branches](MergeProposal.md).
 
-## Chose the appropriate level of scrutiny
+## Review Process
+
+In this review, we:
+* Review formal content for issues
+* Ensure adherence to team style guidelines
+* Identify common issues
+* Conduct further testing (when warranted)
+
+### Chose the appropriate level of scrutiny
 
 Before we go into any details on our review process we have to admit that,
 sometimes a proposal can be rather trivial.
@@ -21,15 +29,7 @@ Therefore we acknoledge that we have two kind of changes we might propose:
   * In this case the review can be free form and rather short
   * But if the reviewer has a hunch or disagrees with that classification they are entitled to do a full pass.
 
-## What we review
-
-In this review, we:
-* Review formal content for issues
-* Ensure adherence to team style guidelines
-* Identify common issues
-* Conduct further testing (when warranted)
-
-## States for each template entry
+### States for each template entry
 
 The following states indicate reviewer feedback on each aspect we check.
 
@@ -39,7 +39,7 @@ The following states indicate reviewer feedback on each aspect we check.
 * *Not applicable* - The particular check is not applicable to this case
 * *Skipped* - Skipped by the reviewer as it seemed not mandatory or commensurate for this case.
 
-## Skipping whole sections
+### Skipping whole sections
 
 Not every change needs all the checks we have in our template. If you would end
 up marking all elements of a section as `skipped` feel free to drop the whole
@@ -48,7 +48,7 @@ section to make the post have a lower percentage of noisy non-content text.
 A common case for this are the checks in regard to "package merges", "new delta
 in debian/", or "new patches".
 
-## How to provide feedback details
+### How to provide feedback details
 
 On any of these states further context might be given in the line below. That is
 entirely optional on "OK" or "Not applicable" and to some extent also for "Skipped" states.
@@ -63,7 +63,13 @@ clear if things are blocking or optional.
 Reviews do not even need to be only critique, if you see something nice
 remember the `praise:` label exists.
 
-## Check the new changelog stanza
+## What we review
+
+The following is an overview of common things we look out for. Obviously each
+case is different and a review can also check for anything else they consider
+appropriate for the situation.
+
+### Check the new changelog stanza
 
 * Contains a bug pointer like `(LP: #12345678)` to all associated cases
 * Correctly formatted entries according to the [changelog policy](https://www.debian.org/doc/debian-policy/ch-source.html#debian-changelog-debian-changelog) and our [hints](PackageMerging.md#fix-the-changelog) for merges
@@ -72,12 +78,12 @@ remember the `praise:` label exists.
 * Proper release - `dch` or habits could have selected the wrong one
 * Proper author and email
 
-## Ensure Documentation/release Notes are updated
+### Ensure Documentation/release Notes are updated
 
 * We always did enqueue things that eventually need to be mentioned in the release notes, this check in the MR review is a reminder about that.
 * If the update/merge has implications that need to be documented we always updated documentation alongside changes. Sometimes things get in via a sync or upstream changes, not by us - as we spot these, make sure to spawn a proper backlog tracker for it.
 
-## Check for indirect changes
+### Check for indirect changes
 
 * Some changes can imply that the packaging needs to be adapted. Check content and release notes if there are any changes like that.
 * When merging from Debian or Upstream it is worth checking if there are even newer versions that would be worth it to go for.
@@ -85,12 +91,12 @@ remember the `praise:` label exists.
 * Ensure that the changes in Debian do not imply that we need to update the delta we carry (do not be fooled by applying cleanly)
 * Ensure update maintainer has been run
 
-## Check the old delta
+### Check the old delta
 
 * Ensure that everything we dropped really can be dropped
   * vice versa, there could be more that could be dropped (often needs a little test to verify which is suggested to the owner of the MR and only rarely done by the reviewer)
 
-## Check the new delta
+### Check the new delta
 
 * Do the patches [follow DEP-3](http://dep.debian.net/deps/dep3/)
   * You can use dep3changelog to verify the headers, as well as generate a changelog entry.
@@ -105,11 +111,11 @@ remember the `praise:` label exists.
   * Or if they are Ubuntu only choices, marked like that so the next packager is not wondering if we want to keep or submit it? (See [`UD-forwarded` for commits](CommittingChanges.md#the-commit-message) and [`Forwarded` for patches](DebianPatch.md#the-patchfile-header).
   * If old delta added in the past does not have such info and you spent the effort to check the history and reasoning to make good decisions, please add the same info to that old-delta.
 
-## Check for Git/maintenance
+### Check for Git/maintenance
 
 * Changes are logically split into separate commits (to ease future merges and cherry picking to other releases)
 
-## Check for Build and Test
+### Check for Build and Test
 
 * Verify that the PPA build is successful on all intended architectures.
 * If this is an SRU consider checking that the SRU template in the bug is OK. Test instructions especially are often only understandable for the reporter. We want them to be good before SRU review.
@@ -121,9 +127,11 @@ remember the `praise:` label exists.
   * In some situations, manual verification of certain behaviors may also be necessary for additional assurance.
 
 
-# Review template
+## Review template
 
-The following template may be useful when submitting reviews:
+The following template may be useful when submitting reviews, it covers all
+the usual checks we describe above making it an easy checkbox approach to not
+miss any.
 
 ```
 Review Symbols:

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -18,6 +18,15 @@ The following states indicate reviewer feedback on each aspect we want to check.
 * *Not applicable* - The particular check is not applicable to this case
 * *Skipped* - Skipped by the reviewer as it seemed not mandatory or commensurate for this case.
 
+## Skipping whole sections
+
+Not every change needs all the checks we have in our template. If you would end
+up marking all elements of a section as `skipped` feel free to drop the whole
+section to make the post have a lower percentage of noisy non-content text.
+
+A common case for this are the checks in regard to "package merges", "new delta
+in debian/", or "new patches".
+
 ## How to provide feedback details
 
 On any of these states further context might be given in the line below. That is

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -18,10 +18,20 @@ The following states indicate reviewer feedback on each aspect we want to check.
 * *Not applicable* - The particular check is not applicable to this case
 * *Skipped* - Skipped by the reviewer as it seemed not mandatory or commensurate for this case.
 
+## How to provide feedback details
+
 On any of these states further context might be given in the line below. That is
-entirely optional on "OK" or "Not applicable" and to some extent also for "Skipped".
-But any "Not OK" and "Question" needs to get some details added so the requester
-can understand and act on it.
+entirely optional on "OK" or "Not applicable" and to some extent also for "Skipped" states.
+But any "Not OK" and "Question" state the reviewer shall provide some details
+to allow the requester to understand and act on it.
+
+Furthermore when providing feedback we strive to follow the style of
+[conventional comments](https://conventionalcomments.org/) which allow us to
+bring up a lot - thereby helping each other - without locking us too much in
+review iterations. Such a simple prefix helps in many common cases, making it
+clear if things are blocking or optional.
+Reviews do not even need to be only critique, if you see something nice
+remember the `praise:` label exists.
 
 ## Check the new changelog stanza
 

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -4,6 +4,23 @@ We established a review process before sponsoring or uploading content, which
 has helped us maintain consistently high quality.
 To do so we propose our changes as [merge proposals against `git-ubuntu` branches](MergeProposal.md).
 
+## Chose the appropriate level of scrutiny
+
+Before we go into any details on our review process we have to admit that,
+sometimes a proposal can be rather trivial.
+And while we love the rigor we have established and holding each other
+accountable to it, we also hate inneficiency.
+
+Therefore we acknoledge that we have two kind of changes we might propose:
+* Changes are complex or there is any kind of remaining uncertainty
+  * Full review please as outlined below (the default)
+* Changes are trivial:
+  * The requester is only looking for a second pair of eyes for lapses that might have happened unaware and unintentionally. But not after a deper check as we'd usually do.
+  * In this case the requester shall mark the proposal by stating "Trivial change" in the description.
+  * Depending on the case that might also lift some other common practise we have like pre-building in PPA and pre-testing autopkgtest against it
+  * In this case the review can be free form and rather short
+  * But if the reviewer has a hunch or disagrees with that classification they are entitled to do a full pass.
+
 ## What we review
 
 In this review, we:

--- a/MergeProposalReview.md
+++ b/MergeProposalReview.md
@@ -12,21 +12,21 @@ In this review, we:
 * Identify common issues
 * Conduct further testing (when warranted)
 
-### Chose the appropriate level of scrutiny
+### Choose the appropriate level of scrutiny
 
 Before we go into any details on our review process we have to admit that,
 sometimes a proposal can be rather trivial.
 And while we love the rigor we have established and holding each other
-accountable to it, we also hate inneficiency.
+accountable to it, we also hate inefficiency.
 
-Therefore we acknoledge that we have two kind of changes we might propose:
+Therefore, we acknoledge that we have two kinds of changes we might propose:
 * Changes are complex or there is any kind of remaining uncertainty
   * Full review please as outlined below (the default)
 * Changes are trivial:
-  * The requester is only looking for a second pair of eyes for lapses that might have happened unaware and unintentionally. But not after a deper check as we'd usually do.
-  * In this case the requester shall mark the proposal by stating "Trivial change" in the description.
-  * Depending on the case that might also lift some other common practise we have like pre-building in PPA and pre-testing autopkgtest against it
-  * In this case the review can be free form and rather short
+  * The requester is only looking for a second pair of eyes for lapses that might have happened unaware and unintentionally. But not after a deeper check as we'd usually do.
+  * In this case the requester shall mark the proposal by stating **Trivial change** in the description.
+  * Depending on the case that might also lift some other common practice we have, like pre-building in PPA and pre-testing autopkgtest against it.
+  * In this case the review can be free form and rather short.
   * But if the reviewer has a hunch or disagrees with that classification they are entitled to do a full pass.
 
 ### States for each template entry
@@ -35,7 +35,7 @@ The following states indicate reviewer feedback on each aspect we check.
 
 * *OK* - This was checked and there was nothing of concern to be raised.
 * *Not OK* - Something is not as it should be and needs to be changed in the proposed content.
-* *Question* - Not neccesarily bad, but a detail worth to clarify. This could only need an answer, but might due to the discussion also end up in changes to what was proposed.
+* *Question* - Not necessarily bad, but a detail worth clarifying. This could only need an answer, but might as a result of the discussion also end up in changes to what was proposed.
 * *Not applicable* - The particular check is not applicable to this case
 * *Skipped* - Skipped by the reviewer as it seemed not mandatory or commensurate for this case.
 
@@ -52,11 +52,11 @@ in debian/", or "new patches".
 
 On any of these states further context might be given in the line below. That is
 entirely optional on "OK" or "Not applicable" and to some extent also for "Skipped" states.
-But any "Not OK" and "Question" state the reviewer shall provide some details
+But for any "Not OK" and "Question" state the reviewer shall provide some details
 to allow the requester to understand and act on it.
 
 Furthermore when providing feedback we strive to follow the style of
-[conventional comments](https://conventionalcomments.org/) which allow us to
+[conventional comments](https://conventionalcomments.org/) which allows us to
 bring up a lot - thereby helping each other - without locking us too much in
 review iterations. Such a simple prefix helps in many common cases, making it
 clear if things are blocking or optional.
@@ -66,7 +66,7 @@ remember the `praise:` label exists.
 ## What we review
 
 The following is an overview of common things we look out for. Obviously each
-case is different and a review can also check for anything else they consider
+case is different and a reviewer can also check for anything else they consider
 appropriate for the situation.
 
 ### Check the new changelog stanza
@@ -129,9 +129,8 @@ appropriate for the situation.
 
 ## Review template
 
-The following template may be useful when submitting reviews, it covers all
-the usual checks we describe above making it an easy checkbox approach to not
-miss any.
+Use this template for reviews; it includes all standard criteria as checkboxes,
+making it easy to avoid omissions.
 
 ```
 Review Symbols:


### PR DESCRIPTION
I've found too often whole sections not applicable, making some otherwise worthwhile checks just a distracting burden to read.
=> Allow one to drop sections if all would be skips

Furthermore I've seen uncertainty like "do you need to re-review after this change". 
=> Some have naturally done that, but https://conventionalcomments.org/ provides a nice framework for it which we could utilize to make our workflow better.