### PR TITLE
Remove note that Server Team package subscription updates will go to the ubuntu-server mailing list

### DIFF
--- a/MainInclusion.md
+++ b/MainInclusion.md
@@ -56,9 +56,7 @@ review from `~canonical-server-reporter`.
 If in doubt, please file a merge proposal anyway.
 
 Once a change has landed into the git repository, a cron job will automatically
-enact the change in Launchpad itself within 24 hours. All automated changes
-made are logged to the
-[ubuntu-server mailing list](https://lists.ubuntu.com/mailman/listinfo/ubuntu-server).
+enact the change in Launchpad itself within 24 hours.
 
 ### Reviewing a merge proposal to change the set of supported packages
 


### PR DESCRIPTION
With the Ubuntu Server mailing list going away soon, package subscription updates are no longer sent there. The server team has decided that public updates are no longer needed for this, so the only change needed here is for the sentence to be removed. I have already made this change on the script side as the maintainer.